### PR TITLE
Add a Dockerfile for stacker.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:alpine
+RUN apk update && apk upgrade
+RUN apk add build-base curl git lxc-dev acl-dev btrfs-progs btrfs-progs-dev \
+    gpgme-dev glib-dev libassuan-dev lvm2-dev bash
+# Install these additional packages from edge. These packages are required by
+# skopeo.
+RUN apk add ostree-dev libselinux-dev --update-cache \
+    --repository http://dl-3.alpinelinux.org/alpine/edge/testing/
+
+RUN curl -s https://glide.sh/get | sh
+RUN go get github.com/openSUSE/umoci/cmd/umoci
+RUN go get github.com/cpuguy83/go-md2man
+
+# skopeo build will fail if we use /bin/sh as the shell.
+SHELL ["/bin/bash", "-c"]
+RUN git clone https://github.com/projectatomic/skopeo \
+    $GOPATH/src/github.com/projectatomic/skopeo && \
+    cd $GOPATH/src/github.com/projectatomic/skopeo && \
+    make binary-local && make install
+
+SHELL ["/bin/sh", "-c"]
+RUN git clone https://github.com/anuvu/stacker.git \
+    $GOPATH/src/github.com/anuvu/stacker && \
+    cd $GOPATH/src/github.com/anuvu/stacker && \
+    make

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# Docker Image
+
+## Image Creation
+
+The `Dockerfile` in this directory can be used to create a Docker image that has
+`stacker` installed in it.
+
+```
+docker build . -t stacker:latest
+```
+
+## Running `stacker`
+
+It is recommended to mount a volume to serve as your work directory in the
+container. First change into the host directory that will serve as your work
+directory.
+
+```
+cd <work directory>
+```
+
+Assuming that you have a stacker file `first.yaml` in your work directory, you
+can create an OCI image non-interactively like this:
+
+```
+docker run --rm --privileged=true -v $(pwd):/volume -t stacker /bin/sh -c 'cd /volume && stacker build -f first.yaml'
+```
+
+You can also drop into an interactive shell inside the container like this:
+
+```
+docker run --rm --privileged=true -v $(pwd):/volume -it stacker /bin/bash
+
+```


### PR DESCRIPTION
Add a Dockerfile to build docker image. This will help folks who want to develop on environments where they don't want to run vagrant. For instance, a developer on macOS can use xhyve/Docker instead of using VirtualBox, or VMWare Fusion.