### PR TITLE
fix docker path

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"path"
 	"reflect"
 	"strings"
 
@@ -68,7 +69,7 @@ func (is *ImageSource) ParseTag() (string, error) {
 		}
 
 		if url.Path != "" {
-			return strings.Split(url.Path, ":")[0], nil
+			return path.Base(strings.Split(url.Path, ":")[0]), nil
 		}
 
 		// skopeo allows docker://centos:latest or


### PR DESCRIPTION
commit 4374239cca broke some builds by trying to skopeo copy
images to, say, "oci:oci:anuvu/anuvu-dev".  That's because
it dropped the 'path.Base(anuvu/anuvu-dev)'.  Re-add that.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>