### PR TITLE
doc: update to reference golang 1.10 and libcap-dev dependency.

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -1,11 +1,15 @@
 ### Building
 
-Stacker requires go 1.9, on Ubuntu you can get that with:
+Stacker requires go 1.10, on Ubuntu 18.04 you can get that with:
+
+    sudo apt install golang
+
+If you are on another Ubuntu release you can use the gophers' ppa:
 
     sudo apt-add-repository ppa:gophers/archive
     sudo apt update
-    sudo apt install golang-1.9
-    export PATH=$PATH:/usr/lib/go-1.9/bin
+    sudo apt install golang-1.10
+    export PATH=$PATH:/usr/lib/go-1.10/bin
 
 And uses glide for dependency management, which unfortunately is installed with
 curl piped to sh as follows:
@@ -14,7 +18,7 @@ curl piped to sh as follows:
 
 Stacker also has the following build dependencies:
 
-    sudo apt install lxc-dev libacl1-dev libgpgme-dev
+    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev
 
 Finally, once you have the build dependencies, stacker can be built with a
 simple `make`. The stacker binary will be output to `$GOPATH/bin/stacker`.


### PR DESCRIPTION
The reference to golang 1.9 is incorrect now as things have moved on.
libcap-dev is needed for sys/capability.h

Signed-off-by: Scott Moser <smoser@brickies.net>