### PR TITLE
Mark dependencies for 'make check'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ vendor: glide.lock
 check:
 	go fmt ./... && ([ -z $(TRAVIS) ] || git diff --quiet)
 	go test ./...
-	sudo -E bats -t $(patsubst %,test/%.bats,$(TEST))
+	sudo -E bats "PATH=$$PATH" -t $(patsubst %,test/%.bats,$(TEST))
 
 .PHONY: vendorup
 vendorup:

--- a/doc/install.md
+++ b/doc/install.md
@@ -16,5 +16,9 @@ Stacker also has the following build dependencies:
 
     sudo apt install lxc-dev libacl1-dev libgpgme-dev
 
+To run `make check` you will also  need:
+
+    sudo apt install bats jq
+
 Finally, once you have the build dependencies, stacker can be built with a
 simple `make`. The stacker binary will be output to `$GOPATH/bin/stacker`.


### PR DESCRIPTION
'make check' uses bats package for unit tests and jq inside the unit
tests for verification.