### PR TITLE
Fix make check failure due to order of arguments to sudo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ vendor: glide.lock
 check:
 	go fmt ./... && ([ -z $(TRAVIS) ] || git diff --quiet)
 	go test ./...
-	sudo -E bats "PATH=$$PATH" -t $(patsubst %,test/%.bats,$(TEST))
+	sudo -E "PATH=$$PATH" bats -t $(patsubst %,test/%.bats,$(TEST))
 
 .PHONY: vendorup
 vendorup:


### PR DESCRIPTION
It should be:
 sudo ENV=VAL command
not
 sudo command ENV=val