### PR TITLE
Pr fixes

### DIFF
--- a/base.go
+++ b/base.go
@@ -232,7 +232,7 @@ func extractOutput(o BaseLayerOpts) error {
 			return err
 		}
 
-		bundlePath := path.Join(o.Config.RootFSDir, ".working")
+		bundlePath := path.Join(o.Config.RootFSDir, WorkingContainerName)
 		err = updateBundleMtree(bundlePath, desc)
 		if err != nil {
 			return err
@@ -264,7 +264,7 @@ func getDocker(o BaseLayerOpts) error {
 func umociInit(o BaseLayerOpts) error {
 	return RunUmociSubcommand(o.Config, o.Debug, []string{
 		"--tag", o.Name,
-		"--bundle-path", path.Join(o.Config.RootFSDir, ".working"),
+		"--bundle-path", path.Join(o.Config.RootFSDir, WorkingContainerName),
 		"init",
 	})
 }

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -62,11 +62,11 @@ func doChroot(ctx *cli.Context) error {
 		cmd = ctx.Args()[1]
 	}
 
-	// It may be useful to do `stacker chroot .working` in order to inspect
+	// It may be useful to do `stacker chroot _working` in order to inspect
 	// the filesystem that just broke. So, let's try to support this. Since
-	// we can't figure out easily which filesystem .working came from, we
+	// we can't figure out easily which filesystem _working came from, we
 	// fake an empty layer.
-	if tag == ".working" {
+	if tag == stacker.WorkingContainerName {
 		return stacker.Run(config, tag, cmd, &stacker.Layer{}, "", os.Stdin)
 	}
 
@@ -82,8 +82,8 @@ func doChroot(ctx *cli.Context) error {
 		return fmt.Errorf("no layer %s in stackerfile", tag)
 	}
 
-	defer s.Delete(".working")
-	err = s.Restore(tag, ".working")
+	defer s.Delete(stacker.WorkingContainerName)
+	err = s.Restore(tag, stacker.WorkingContainerName)
 	if err != nil {
 		return err
 	}

--- a/cmd/grab.go
+++ b/cmd/grab.go
@@ -31,11 +31,11 @@ func doGrab(ctx *cli.Context) error {
 		return errors.Errorf("invalid grab argument: %s", ctx.Args().First())
 	}
 
-	err = s.Restore(parts[0], ".working")
+	err = s.Restore(parts[0], stacker.WorkingContainerName)
 	if err != nil {
 		return err
 	}
-	defer s.Delete(".working")
+	defer s.Delete(stacker.WorkingContainerName)
 
 	return stacker.Grab(config, parts[0], parts[1])
 }

--- a/cmd/umoci.go
+++ b/cmd/umoci.go
@@ -127,16 +127,16 @@ func doUnpack(ctx *cli.Context) error {
 	if highestHash != "" {
 		// Delete the previously created working snapshot; we're about
 		// to create a new one.
-		err = storage.Delete(".working")
+		err = storage.Delete(stacker.WorkingContainerName)
 		if err != nil {
 			return err
 		}
 
 		// TODO: this is a little wonky: we're assuming that
-		// bundle-path ends in .working. It always does because
+		// bundle-path ends in _working. It always does because
 		// this is an internal API, but we should refactor this
 		// a bit.
-		err = storage.Restore(highestHash, ".working")
+		err = storage.Restore(highestHash, stacker.WorkingContainerName)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func doUnpack(ctx *cli.Context) error {
 				return err
 			}
 
-			err = storage.Snapshot(".working", highestHash)
+			err = storage.Snapshot(stacker.WorkingContainerName, highestHash)
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func doUnpack(ctx *cli.Context) error {
 			return err
 		}
 
-		return storage.Snapshot(".working", hash)
+		return storage.Snapshot(stacker.WorkingContainerName, hash)
 	}
 
 	opts := layer.MapOptions{KeepDirlinks: true}

--- a/cmd/unlade.go
+++ b/cmd/unlade.go
@@ -42,22 +42,22 @@ func doUnlade(ctx *cli.Context) error {
 
 	fmt.Printf("Unpacking all layers from %s into %s\n", config.OCIDir, config.RootFSDir)
 	for idx, tag := range tags {
-		s.Delete(".working")
-		err = s.Create(".working")
+		s.Delete(stacker.WorkingContainerName)
+		err = s.Create(stacker.WorkingContainerName)
 		if err != nil {
 			return err
 		}
 		fmt.Printf("%d/%d: unpacking %s", idx+1, len(tags), tag)
 		err = stacker.RunUmociSubcommand(config, debug, []string{
 			"--tag", tag,
-			"--bundle-path", path.Join(config.RootFSDir, ".working"),
+			"--bundle-path", path.Join(config.RootFSDir, stacker.WorkingContainerName),
 			"unpack",
 		})
 		if err != nil {
 			return err
 		}
 		fmt.Printf(" - done.\n")
-		err = s.Snapshot(".working", tag)
+		err = s.Snapshot(stacker.WorkingContainerName, tag)
 		if err != nil {
 			return err
 		}

--- a/container.go
+++ b/container.go
@@ -134,6 +134,7 @@ func newContainer(sc StackerConfig, name string) (*container, error) {
 	configs := map[string]string{
 		"lxc.mount.auto":  "proc:mixed",
 		"lxc.autodev":     "1",
+		"lxc.mount.entry": "none dev/shm tmpfs defaults,create=dir 0 0",
 		"lxc.uts.name":    name,
 		"lxc.net.0.type":  "none",
 		"lxc.environment": fmt.Sprintf("PATH=%s", ReasonableDefaultPath),

--- a/container.go
+++ b/container.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	ReasonableDefaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	WorkingContainerName  = "_working"
 )
 
 var (

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -28,7 +28,7 @@ With this stacker file as `first.yaml`, we can do a basic stacker build:
      862 B / 862 B [============================================================] 0s
     Writing manifest to image destination
     Storing signatures
-    unpacking to /home/ubuntu/tutorial/roots/.working
+    unpacking to /home/ubuntu/tutorial/roots/_working
     running commands...
     generating layer...
     filesystem first built successfully
@@ -83,7 +83,7 @@ output will look something like:
 	 862 B / 862 B [============================================================] 0s
 	Writing manifest to image destination
 	Storing signatures
-	unpacking to /home/ubuntu/tutorial/roots/.working
+	unpacking to /home/ubuntu/tutorial/roots/_working
 	running commands...
 	running commands for first
 	+ mkdir -p /etc/myapp

--- a/grab.go
+++ b/grab.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Grab(sc StackerConfig, name string, source string) error {
-	c, err := newContainer(sc, ".working")
+	c, err := newContainer(sc, WorkingContainerName)
 	if err != nil {
 		return err
 	}
@@ -22,7 +22,7 @@ func Grab(sc StackerConfig, name string, source string) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(path.Join(sc.RootFSDir, ".working", "rootfs", "stacker"))
+	defer os.Remove(path.Join(sc.RootFSDir, WorkingContainerName, "rootfs", "stacker"))
 
 	return c.execute(fmt.Sprintf("cp -a %s /stacker", source), nil)
 }

--- a/run.go
+++ b/run.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Run(sc StackerConfig, name string, command string, l *Layer, onFailure string, stdin io.Reader) error {
-	c, err := newContainer(sc, ".working")
+	c, err := newContainer(sc, WorkingContainerName)
 	if err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func Run(sc StackerConfig, name string, command string, l *Layer, onFailure stri
 		if err != nil {
 			return err
 		}
-		defer os.Remove(path.Join(sc.RootFSDir, ".working", "rootfs", "stacker"))
+		defer os.Remove(path.Join(sc.RootFSDir, WorkingContainerName, "rootfs", "stacker"))
 	}
 
 	err = c.bindMount("/etc/resolv.conf", "/etc/resolv.conf", "")

--- a/test/intermediate-base-snapshots.bats
+++ b/test/intermediate-base-snapshots.bats
@@ -58,7 +58,7 @@ EOF
     umoci gc --layout oci
     btrfs property set -ts "roots/test" ro false
     btrfs subvolume delete "roots/test"
-    btrfs property list -ts roots/.working
+    btrfs property list -ts roots/_working
 
     stacker build --leave-unladen
     [ -f roots/test/rootfs/surgery ]


### PR DESCRIPTION
This PR introduces two changes:
* change the .working container name to _working as valid dns names can't begin with a `.` this messes up some test suites
* add /dev/shm support, as it exists on standard Linux hosts