### PR TITLE
Add support for pty's

### DIFF
--- a/container.go
+++ b/container.go
@@ -135,6 +135,7 @@ func newContainer(sc StackerConfig, name string) (*container, error) {
 	configs := map[string]string{
 		"lxc.mount.auto":  "proc:mixed",
 		"lxc.autodev":     "1",
+		"lxc.pty.max":     "1024",
 		"lxc.mount.entry": "none dev/shm tmpfs defaults,create=dir 0 0",
 		"lxc.uts.name":    name,
 		"lxc.net.0.type":  "none",


### PR DESCRIPTION
Currently stacker does not expose /dev/ptmx and does not mount /dev/pts this patch fixes this as it is needed by various software, ssh, python's test suite, etc