### PR TITLE
Building multiple stacker recipes in same execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.swp
 *.stacker
 stacker
+
+# IDEs
+.vscode
+.idea

--- a/base.go
+++ b/base.go
@@ -35,13 +35,13 @@ type BaseLayerOpts struct {
 	Debug     bool
 }
 
-func GetBaseLayer(o BaseLayerOpts, sfs []*Stackerfile) error {
+func GetBaseLayer(o BaseLayerOpts, sfm StackerFiles) error {
 	// delete the tag if it exists
 	o.OCI.DeleteReference(context.Background(), o.Name)
 
 	switch o.Layer.From.Type {
 	case BuiltType:
-		return getBuilt(o, sfs)
+		return getBuilt(o, sfm)
 	case TarType:
 		return getTar(o)
 	case OCIType:
@@ -316,27 +316,22 @@ func getOCI(o BaseLayerOpts) error {
 	return extractOutput(o)
 }
 
-func getBuilt(o BaseLayerOpts, sfs []*Stackerfile) error {
+func getBuilt(o BaseLayerOpts, sfm StackerFiles) error {
 	// We need to copy any base OCI layers to the output dir, since they
 	// may not have been copied before and the final `umoci repack` expects
 	// them to be there.
 	base := o.Layer
 	for {
-		// Iterate through base layers until we find the first one with is not BuiltType
-		ok := false
-		for _, sf := range sfs {
-			// Do not override base just to check if the key exists,
-			// as we may need it for base.From.Tag in the next iteration of the look
-			_, ok = sf.Get(base.From.Tag)
-			if ok {
-				// Since the key exists, override the value of base
-				base, _ = sf.Get(base.From.Tag)
-				break
-			}
-		}
+		// Iterate through base layers until we find the first one which is not BuiltType
+		// Need to declare ok separately, if we do it in the same line as
+		// assigning the new value to base, base would be a new variable only in the scope
+		// of this iteration and we never meet the condition to exit the loop
+		var ok bool
+		base, ok = sfm.LookupLayerDefinition(base.From.Tag)
 		if !ok {
-			return fmt.Errorf("missing base layer: %s?", o.Layer.From.Tag)
+			return fmt.Errorf("missing base layer: %s?", base.From.Tag)
 		}
+
 		if base.From.Type != BuiltType {
 			break
 		}

--- a/build.go
+++ b/build.go
@@ -313,14 +313,14 @@ func generateSquashfsLayer(oci casext.Engine, name string, author string, opts *
 
 // Builder is responsible for building the layers based on stackerfiles
 type Builder struct {
-	builtStackerfiles []*Stackerfile // Keep track of all the Stackerfiles which were built
-	opts              *BuildArgs     // Build options
+	builtStackerfiles StackerFiles // Keep track of all the Stackerfiles which were built
+	opts              *BuildArgs   // Build options
 }
 
 // NewBuilder initializes a new Builder struct
 func NewBuilder(opts *BuildArgs) *Builder {
 	return &Builder{
-		builtStackerfiles: []*Stackerfile{},
+		builtStackerfiles: make(map[string]*Stackerfile, 1),
 		opts:              opts,
 	}
 }
@@ -363,7 +363,7 @@ func (b *Builder) Build(file string) error {
 	defer oci.Close()
 
 	// Add this stackerfile to the list of stackerfiles which were built
-	b.builtStackerfiles = append(b.builtStackerfiles, sf)
+	b.builtStackerfiles[file] = sf
 	buildCache, err := OpenCache(opts.Config, oci, b.builtStackerfiles)
 	if err != nil {
 		return err
@@ -399,7 +399,6 @@ func (b *Builder) Build(file string) error {
 	author := fmt.Sprintf("%s@%s", username, host)
 
 	s.Delete(WorkingContainerName)
-
 	for _, name := range order {
 		l, ok := sf.Get(name)
 		if !ok {

--- a/cache.go
+++ b/cache.go
@@ -65,18 +65,18 @@ type CacheEntry struct {
 type BuildCache struct {
 	path       string
 	importsDir string
-	sf         *Stackerfile
+	sfs        []*Stackerfile
 	Cache      map[string]CacheEntry `json:"cache"`
 	Version    int                   `json:"version"`
 }
 
-func OpenCache(config StackerConfig, oci casext.Engine, sf *Stackerfile) (*BuildCache, error) {
+func OpenCache(config StackerConfig, oci casext.Engine, sfs []*Stackerfile) (*BuildCache, error) {
 	p := path.Join(config.StackerDir, "build.cache")
 	f, err := os.Open(p)
 	cache := &BuildCache{
 		path:       p,
 		importsDir: path.Join(config.StackerDir, "imports"),
-		sf:         sf,
+		sfs:        sfs,
 	}
 
 	if err != nil {
@@ -158,8 +158,18 @@ func hashFile(path string) (string, error) {
 	return d.String(), nil
 }
 
+func (c *BuildCache) lookupLayerDefinition(name string) (*Layer, bool) {
+	for _, sf := range c.sfs {
+		l, found := sf.Get(name)
+		if found {
+			return l, true
+		}
+	}
+	return nil, false
+}
+
 func (c *BuildCache) Lookup(name string) (*CacheEntry, bool) {
-	l, ok := c.sf.Get(name)
+	l, ok := c.lookupLayerDefinition(name)
 	if !ok {
 		return nil, false
 	}
@@ -269,7 +279,7 @@ func getEncodedMtree(path string) (string, error) {
 }
 
 func (c *BuildCache) getBaseHash(name string) (string, error) {
-	l, ok := c.sf.Get(name)
+	l, ok := c.lookupLayerDefinition(name)
 	if !ok {
 		return "", fmt.Errorf("%s missing from stackerfile?", name)
 	}
@@ -292,7 +302,7 @@ func (c *BuildCache) getBaseHash(name string) (string, error) {
 }
 
 func (c *BuildCache) Put(name string, blob ispec.Descriptor) error {
-	l, ok := c.sf.Get(name)
+	l, ok := c.lookupLayerDefinition(name)
 	if !ok {
 		return fmt.Errorf("%s missing from stackerfile?", name)
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -37,7 +37,7 @@ func TestLayerHashing(t *testing.T) {
 		},
 	}
 
-	cache, err := OpenCache(config, casext.Engine{}, sf)
+	cache, err := OpenCache(config, casext.Engine{}, []*Stackerfile{sf})
 	if err != nil {
 		t.Fatalf("couldn't open cache %v", err)
 	}
@@ -58,7 +58,7 @@ func TestLayerHashing(t *testing.T) {
 	layer.Run = []string{"jmh"}
 
 	// ok, now re-load the persisted cache
-	cache, err = OpenCache(config, casext.Engine{}, sf)
+	cache, err = OpenCache(config, casext.Engine{}, []*Stackerfile{sf})
 	if err != nil {
 		t.Fatalf("couldn't re-load cache %v", err)
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -37,7 +37,7 @@ func TestLayerHashing(t *testing.T) {
 		},
 	}
 
-	cache, err := OpenCache(config, casext.Engine{}, []*Stackerfile{sf})
+	cache, err := OpenCache(config, casext.Engine{}, StackerFiles{"dummy": sf})
 	if err != nil {
 		t.Fatalf("couldn't open cache %v", err)
 	}
@@ -58,7 +58,7 @@ func TestLayerHashing(t *testing.T) {
 	layer.Run = []string{"jmh"}
 
 	// ok, now re-load the persisted cache
-	cache, err = OpenCache(config, casext.Engine{}, []*Stackerfile{sf})
+	cache, err = OpenCache(config, casext.Engine{}, StackerFiles{"dummy": sf})
 	if err != nil {
 		t.Fatalf("couldn't re-load cache %v", err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -46,6 +46,10 @@ var buildCmd = cli.Command{
 			Usage: "set the output layer type (supported values: tar, squashfs)",
 			Value: "tar",
 		},
+		cli.BoolFlag{
+			Name:  "order-only",
+			Usage: "show the build order without running the actual build",
+		},
 	},
 	Before: beforeBuild,
 }
@@ -79,14 +83,15 @@ func doBuild(ctx *cli.Context) error {
 	args := stacker.BuildArgs{
 		Config:                  config,
 		LeaveUnladen:            ctx.Bool("leave-unladen"),
-		StackerFile:             ctx.String("stacker-file"),
 		NoCache:                 ctx.Bool("no-cache"),
 		Substitute:              ctx.StringSlice("substitute"),
 		OnRunFailure:            ctx.String("on-run-failure"),
 		ApplyConsiderTimestamps: ctx.Bool("apply-consider-timestamps"),
 		LayerType:               ctx.String("layer-type"),
+		OrderOnly:               ctx.Bool("order-only"),
 		Debug:                   debug,
 	}
 
-	return stacker.Build(&args)
+	builder := stacker.NewBuilder(&args)
+	return builder.BuildMultiple([]string{ctx.String("stacker-file")})
 }

--- a/deps.go
+++ b/deps.go
@@ -10,7 +10,7 @@ type StackerFilesDAG struct {
 }
 
 // NewStackerDepsDAG properly initializes a StackerDepsProcessor
-func NewStackerFilesDAG(sfMap map[string]*Stackerfile) (*StackerFilesDAG, error) {
+func NewStackerFilesDAG(sfMap StackerFiles) (*StackerFilesDAG, error) {
 	dag := lib.NewDAG()
 
 	// Add vertices to dag

--- a/deps.go
+++ b/deps.go
@@ -1,0 +1,62 @@
+package stacker
+
+import (
+	"github.com/anuvu/stacker/lib"
+)
+
+// StackerDepsDAG processes the dependencies between different stacker recipes
+type StackerFilesDAG struct {
+	dag lib.Graph
+}
+
+// NewStackerDepsDAG properly initializes a StackerDepsProcessor
+func NewStackerFilesDAG(sfMap map[string]*Stackerfile) (*StackerFilesDAG, error) {
+	dag := lib.NewDAG()
+
+	// Add vertices to dag
+	for path, sf := range sfMap {
+		// Add a vertex for every StackerFile object
+		err := dag.AddVertex(path, sf)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Update the dependencies in the dag
+	for path, sf := range sfMap {
+		prerequisites, err := sf.Prerequisites()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, depPath := range prerequisites {
+			err := dag.AddDependencies(path, depPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	p := StackerFilesDAG{
+		dag: dag,
+	}
+	return &p, nil
+}
+
+func (d *StackerFilesDAG) GetStackerFile(path string) *Stackerfile {
+	value := d.dag.GetValue(path)
+	return value.(*Stackerfile)
+}
+
+// Sort provides a serial build order for the stacker files
+func (d *StackerFilesDAG) Sort() []string {
+	var order []string
+
+	// Use dag.Sort() to ensure we always process targets in order of their dependencies
+	for _, i := range d.dag.Sort() {
+		path := i.Key.(string)
+		order = append(order, path)
+	}
+
+	return order
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/sergi/go-diff v0.0.0-20180205163309-da645544ed44
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/tchap/go-patricia v2.3.0+incompatible // indirect
+	github.com/twmb/algoimpl v0.0.0-20170717182524-076353e90b94
 	github.com/udhos/equalfile v0.3.0
 	github.com/ulikunitz/xz v0.5.5 // indirect
 	github.com/urfave/cli v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.3.0+incompatible h1:GkY4dP3cEfEASBPPkWd+AmjYxhmDkqO9/zg7R0lSQRs=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/twmb/algoimpl v0.0.0-20170717182524-076353e90b94 h1:RVeQNVS7eoXqFemL1LnyzV7yuijHlBtiq6lH5T/mljw=
+github.com/twmb/algoimpl v0.0.0-20170717182524-076353e90b94/go.mod h1:+E0GZE9c8UBk2GYXo9mPIHAtmmBkJlSWCdzLMcsCWV0=
 github.com/tych0/umoci v0.1.1-0.20190402232331-556620754fb1 h1:o4wA23uJTjELWzDPI9c5fWshoXr5iMY8gbt0Vz2bM9Y=
 github.com/tych0/umoci v0.1.1-0.20190402232331-556620754fb1/go.mod h1:r5Md+fkaQUURwsULEptlOz0Vv2QlzbdbfHi+eBkk2uU=
 github.com/udhos/equalfile v0.3.0 h1:KhG4xhhkittrgIV/ekHtpEPh7MLxtbjm6kLEwp5Dlbg=

--- a/lib/dag.go
+++ b/lib/dag.go
@@ -6,8 +6,6 @@ import (
 	"github.com/twmb/algoimpl/go/graph"
 )
 
-// This file is a copy from cube/gobi to avoid deps on cube/gobi
-
 // DAG is responsible to gather all the components and their dependencies,
 // and then returns a list of components sorted from no dependencies to
 // the one with most dependencies. In that way we can prioritize creating the

--- a/lib/dag.go
+++ b/lib/dag.go
@@ -1,0 +1,177 @@
+package lib
+
+import (
+	"fmt"
+
+	"github.com/twmb/algoimpl/go/graph"
+)
+
+// This file is a copy from cube/gobi to avoid deps on cube/gobi
+
+// DAG is responsible to gather all the components and their dependencies,
+// and then returns a list of components sorted from no dependencies to
+// the one with most dependencies. In that way we can prioritize creating the
+// components and ensuring it is not going to fail because of lack of dependent object.
+
+// Key for a component
+type Key interface{}
+
+// Value is the actual component object
+type Value interface{}
+
+// Graph is collection of vertices and edges between them.
+// In dag, sort implement a topological sort for the graph.
+type Graph interface {
+	// AddVertex creates a new vertex in the graph with the specified key and stores
+	// value provided in the vertex. It returns an error if the vertex specified by
+	// the key already exists.
+	AddVertex(Key, Value) error
+
+	// RemoveVertex removes the vertex specified by the key. It returns an error
+	// if the vertex corresponding to the key is not present in the graph.
+	RemoveVertex(Key) error
+
+	// AddDependencies creates a dependency between a given vertex and the provided
+	// list of dependency vertices. This returns an error if either the vertex or the
+	// dependency is not present in the graph or a make a node depends on itself.
+	// Adding an dependency that creates a cycle in the graph is not allowed.
+	AddDependencies(Key, ...Key) error
+
+	// GetValue returns the value of the vertex specified by the key. It returns nil if the
+	// vertex is not present in the graph.
+	GetValue(Key) Value
+
+	// SetValue sets the value of the vertex specified by the key. It returns an error if
+	// the vertex is not present in the graph
+	SetValue(Key, Value) error
+
+	// Sort returns all the vertex entries in the dependency order. Vertices are ordered in
+	// such a way that a vertex's dependencies will always preseed itself.
+	Sort() []Vertex
+}
+
+// NewDAG creates a new DAG.
+func NewDAG() Graph {
+	return &dag{
+		graph.New(graph.Directed),
+		make(map[Key]graph.Node),
+	}
+}
+
+// Vertex in the graph has the entry of <key, value> for a component
+type Vertex struct {
+	Key   Key
+	Value Value
+}
+
+// dag is a Graph which has an internal graph.Graph inside itself handling
+// nodes creation and making edges. It also has a map of all vertices which associates
+// the key to a graph.Node that is holding their corresponding component.
+type dag struct {
+	graph    *graph.Graph
+	vertices map[Key]graph.Node
+}
+
+func (dg *dag) AddVertex(key Key, val Value) error {
+	if _, ok := dg.vertices[key]; ok {
+		return fmt.Errorf("key %s already exists", key)
+	}
+	node := dg.graph.MakeNode()
+	*node.Value = &Vertex{key, val}
+	dg.vertices[key] = node
+	return nil
+}
+
+func (dg *dag) RemoveVertex(key Key) error {
+	v, ok := dg.vertices[key]
+	if !ok {
+		return fmt.Errorf("key %s does not exist", key)
+	}
+	dg.graph.RemoveNode(&v)
+	delete(dg.vertices, key)
+	return nil
+}
+
+func (dg *dag) AddDependencies(vertex Key, dependencies ...Key) error {
+	for _, dep := range dependencies {
+		srcObj, ok := dg.vertices[vertex]
+		if !ok {
+			return fmt.Errorf("key %s does not exist", vertex)
+		}
+
+		if err := dg.addDep(srcObj, vertex, dep); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// adds a single dependency to the graph
+func (dg *dag) addDep(srcObj graph.Node, node Key, dependency Key) error {
+	dstObj, ok := dg.vertices[dependency]
+	if !ok {
+		return fmt.Errorf("key %s does not exist", dependency)
+	}
+
+	if node == dependency {
+		return fmt.Errorf("edge to self is not allowed")
+	}
+
+	if err := dg.graph.MakeEdge(dstObj, srcObj); err != nil {
+		return err
+	}
+
+	if !isAcyclic(dg) {
+		dg.graph.RemoveEdge(dstObj, srcObj)
+		return fmt.Errorf("edge from %s to %s makes a cycle", node, dependency)
+	}
+	return nil
+
+}
+
+// Return the vertex by its key if exists else return nil.
+func (dg *dag) GetValue(v Key) Value {
+	if o, ok := dg.vertices[v]; ok {
+		vertex := (*o.Value).(*Vertex)
+		return vertex.Value
+	}
+	return nil
+}
+
+// Set the value of the vertex if exists else return error.
+func (dg *dag) SetValue(v Key, val Value) error {
+	if o, ok := dg.vertices[v]; ok {
+		vertex := (*o.Value).(*Vertex)
+		vertex.Value = val
+		return nil
+	}
+	return fmt.Errorf("key %s does not exist", v)
+}
+
+// A sorted traversal of this graph will guarantee the
+// dependency order. This means A (node) depends on B (dependency) then
+// the sorted traversal will always return B before A.
+func (dg *dag) Sort() []Vertex {
+	sorted := dg.graph.TopologicalSort()
+	nodes := make([]Vertex, 0, len(sorted))
+	for _, n := range sorted {
+		vp := (*n.Value).(*Vertex)
+		n := Vertex{vp.Key, vp.Value}
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// Determines whether a DAG is acyclic or not.
+func isAcyclic(dg *dag) bool {
+	connectedComponents := dg.graph.StronglyConnectedComponents()
+	// If the arrays underlying each node has a size of one, it means that each
+	// vertex in the dag is a connected component. There's not any connected component
+	// with more than one vertex in it. Therefore there isn't any cycle in the DAG.
+	for _, arr := range connectedComponents {
+		if len(arr) > 1 {
+			return false
+		}
+	}
+	return true
+}

--- a/run.go
+++ b/run.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
 )
 
 func Run(sc StackerConfig, name string, command string, l *Layer, onFailure string, stdin io.Reader) error {
@@ -34,18 +33,7 @@ func Run(sc StackerConfig, name string, command string, l *Layer, onFailure stri
 		return err
 	}
 
-	for _, bind := range binds {
-		parts := strings.Split(bind, "->")
-		if len(parts) != 1 && len(parts) != 2 {
-			return fmt.Errorf("invalid bind mount %s", bind)
-		}
-
-		source := strings.TrimSpace(parts[0])
-		target := source
-		if len(parts) == 2 {
-			target = strings.TrimSpace(parts[1])
-		}
-
+	for source, target := range binds {
 		err = c.bindMount(source, target, "")
 		if err != nil {
 			return err

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -1,0 +1,86 @@
+load helpers
+
+function setup() {
+    cleanup
+    rm -rf ocibuilds || true
+    mkdir -p ocibuilds/sub1
+    touch ocibuilds/sub1/import1
+    cat > ocibuilds/sub1/stacker.yaml <<EOF
+layer1_1:
+    from:
+        type: docker
+        url: docker://centos:latest
+    import:
+        - import1
+    run: |
+        cp /stacker/import1 /root/import1
+layer1_2:
+    from:
+        type: docker
+        url: docker://centos:latest
+    run:
+        touch /root/import0
+EOF
+    mkdir -p ocibuilds/sub2
+    touch ocibuilds/sub2/import2
+    cat > ocibuilds/sub2/stacker.yaml <<EOF
+stacker_config:
+    prerequisites:
+        - ../sub1/stacker.yaml
+layer2:
+    from:
+        type: built
+        tag: layer1_1
+    import:
+        - import2
+    run: |
+        cp /stacker/import2 /root/import2
+        cp /root/import1 /root/import1_copied
+EOF
+    mkdir -p ocibuilds/sub3
+    cat > ocibuilds/sub3/stacker.yaml <<EOF
+stacker_config:
+    prerequisites:
+        - ../sub1/stacker.yaml
+        - ../sub2/stacker.yaml
+layer3_1:
+    from:
+        type: built
+        tag: layer2
+    run: |
+        cp /root/import2 /root/import2_copied
+layer3_2:
+    from:
+        type: built
+        tag: layer1_2
+    run: |
+        cp /root/import0 /root/import0_copied
+EOF
+}
+
+function teardown() {
+    cleanup
+    rm -rf ocibuilds || true
+}
+
+@test "order prerequisites" {
+    stacker build -f ocibuilds/sub3/stacker.yaml --order-only
+    [[ "${lines[-1]}" =~ ^(2 build .*ocibuilds\/sub3\/stacker\.yaml: requires: \[.*\/sub1\/stacker\.yaml .*\/sub2\/stacker\.yaml\])$ ]]
+    [[ "${lines[-2]}" =~ ^(1 build .*ocibuilds\/sub2\/stacker\.yaml: requires: \[.*\/sub1\/stacker\.yaml\])$ ]]
+    [[ "${lines[-3]}" =~ ^(0 build .*ocibuilds\/sub1\/stacker\.yaml: requires: \[\])$ ]]
+}
+
+@test "build layers and prerequisites" {
+    stacker build -f ocibuilds/sub3/stacker.yaml
+    mkdir dest
+    umoci unpack --image oci:layer3_1 dest/layer3_1
+    [ "$status" -eq 0 ]
+    [ -f dest/layer3_1/rootfs/root/import2_copied ]
+    [ -f dest/layer3_1/rootfs/root/import2 ]
+    [ -f dest/layer3_1/rootfs/root/import1_copied ]
+    [ -f dest/layer3_1/rootfs/root/import1 ]
+    umoci unpack --image oci:layer3_2 dest/layer3_2
+    [ "$status" -eq 0 ]
+    [ -f dest/layer3_2/rootfs/root/import0_copied ]
+    [ -f dest/layer3_2/rootfs/root/import0 ]
+}


### PR DESCRIPTION
1. Changes in this PR
- Update the stacker recipe to add a 'stacker_config' key. The 'stacker_config' contains build configuration for all the layers in the stacker recipe. For now the only key in 'stacker_config' is 'include'. 'include' contains paths to other stacker recipes which contain layers which should be built before the current stacker recipe.
- Modified the 'stacker build' command to also build the layers mentioned in the 'include' section of the stacker recipe (and other includes found in those recipes, recursively). 
This behavior can be disabled with a '--no-includes' flag.
- Other changes which are prerequisites for the above.

2. If this PR is OK, we can move forward and:
- Add a separate command to search for stacker recipes in the file system using a regex, and arrange them in order according to dependencies, and build them. Or we can add another set of flags to indicate a pattern / search folder to the build command itself, which would be mutually exclusive with '-f'. 
- Come up with a mechanism for caching layers in dockerhub.