### PR TITLE
build.go: switch from bash to sh

### DIFF
--- a/build.go
+++ b/build.go
@@ -467,14 +467,14 @@ func Build(opts *BuildArgs) error {
 		}
 
 		if len(run) != 0 {
-			_, err := os.Stat(path.Join(opts.Config.RootFSDir, WorkingContainerName, "rootfs/bin/bash"))
+			_, err := os.Stat(path.Join(opts.Config.RootFSDir, WorkingContainerName, "rootfs/bin/sh"))
 			if err != nil {
-				return fmt.Errorf("rootfs for %s does not have a /bin/bash", name)
+				return fmt.Errorf("rootfs for %s does not have a /bin/sh", name)
 			}
 
 			importsDir := path.Join(opts.Config.StackerDir, "imports", name)
 
-			script := fmt.Sprintf("#!/bin/bash -xe\n%s", strings.Join(run, "\n"))
+			script := fmt.Sprintf("#!/bin/sh -xe\n%s", strings.Join(run, "\n"))
 			if err := ioutil.WriteFile(path.Join(importsDir, ".stacker-run.sh"), []byte(script), 0755); err != nil {
 				return err
 			}

--- a/test/scratch.bats
+++ b/test/scratch.bats
@@ -15,7 +15,7 @@ EOF
     [ "$(ls dest/rootfs)" == "" ]
 }
 
-@test "/bin/bash present check" {
+@test "/bin/sh present check" {
     cat > stacker.yaml <<EOF
 empty:
     from:
@@ -23,5 +23,5 @@ empty:
     run: /bin/true
 EOF
     bad_stacker build
-    echo "$output" | grep "rootfs for empty does not have a /bin/bash"
+    echo "$output" | grep "rootfs for empty does not have a /bin/sh"
 }


### PR DESCRIPTION
Alpine doesn't provide bash by default.  Which means we cannot
build FROM: alpine with a run: section.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>