### PR TITLE
Allow building of multiple stackerfiles sent from command line with '-f' 

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,10 +16,9 @@ var buildCmd = cli.Command{
 			Name:  "leave-unladen",
 			Usage: "leave the built rootfs mount after image building",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:  "stacker-file, f",
 			Usage: "the input stackerfile",
-			Value: "stacker.yaml",
 		},
 		cli.BoolFlag{
 			Name:  "no-cache",
@@ -66,6 +65,13 @@ func beforeBuild(ctx *cli.Context) error {
 		}
 	}
 
+	if len(ctx.StringSlice("stacker-file")) == 0 {
+		err := ctx.Set("stacker-file", "stacker.yaml")
+		if err != nil {
+			return err
+		}
+	}
+
 	switch ctx.String("layer-type") {
 	case "tar":
 		break
@@ -93,5 +99,5 @@ func doBuild(ctx *cli.Context) error {
 	}
 
 	builder := stacker.NewBuilder(&args)
-	return builder.BuildMultiple([]string{ctx.String("stacker-file")})
+	return builder.BuildMultiple(ctx.StringSlice("stacker-file"))
 }

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -56,6 +56,33 @@ layer3_2:
     run: |
         cp /root/import0 /root/import0_copied
 EOF
+    mkdir -p ocibuilds/sub4
+    touch ocibuilds/sub4/import4
+    cat > ocibuilds/sub4/stacker.yaml <<EOF
+layer4:
+    from:
+        type: docker
+        url: docker://centos:latest
+    import:
+        - import4
+    run: |
+        cp /stacker/import4 /root/import4
+EOF
+    mkdir -p ocibuilds/sub5
+    touch ocibuilds/sub5/import5
+    cat > ocibuilds/sub5/stacker.yaml <<EOF
+stacker_config:
+    prerequisites:
+        - ../sub4/stacker.yaml
+layer5:
+    from:
+        type: built
+        tag: layer4
+    import:
+        - import5
+    run: |
+        cp /stacker/import5 /root/import5
+EOF
 }
 
 function teardown() {
@@ -70,7 +97,7 @@ function teardown() {
     [[ "${lines[-3]}" =~ ^(0 build .*ocibuilds\/sub1\/stacker\.yaml: requires: \[\])$ ]]
 }
 
-@test "build layers and prerequisites" {
+@test "build layers and prerequisites for a single stackerfile" {
     stacker build -f ocibuilds/sub3/stacker.yaml
     mkdir dest
     umoci unpack --image oci:layer3_1 dest/layer3_1
@@ -83,4 +110,23 @@ function teardown() {
     [ "$status" -eq 0 ]
     [ -f dest/layer3_2/rootfs/root/import0_copied ]
     [ -f dest/layer3_2/rootfs/root/import0 ]
+}
+
+@test "build layers and prerequisites for multiple stackerfiles" {
+    stacker build -f ocibuilds/sub5/stacker.yaml -f ocibuilds/sub3/stacker.yaml
+    mkdir dest
+    umoci unpack --image oci:layer3_1 dest/layer3_1
+    [ "$status" -eq 0 ]
+    [ -f dest/layer3_1/rootfs/root/import2_copied ]
+    [ -f dest/layer3_1/rootfs/root/import2 ]
+    [ -f dest/layer3_1/rootfs/root/import1_copied ]
+    [ -f dest/layer3_1/rootfs/root/import1 ]
+    umoci unpack --image oci:layer3_2 dest/layer3_2
+    [ "$status" -eq 0 ]
+    [ -f dest/layer3_2/rootfs/root/import0_copied ]
+    [ -f dest/layer3_2/rootfs/root/import0 ]
+    umoci unpack --image oci:layer5 dest/layer5
+    [ "$status" -eq 0 ]
+    [ -f dest/layer5/rootfs/root/import4 ]
+    [ -f dest/layer5/rootfs/root/import5 ]
 }


### PR DESCRIPTION
This is for building stackerfiles which do not depend on each other, but may have the same base images.