### PR TITLE
Add the option to save the new layers to a remote location

### DIFF
--- a/api.go
+++ b/api.go
@@ -34,6 +34,7 @@ type StackerConfig struct {
 
 type BuildConfig struct {
 	Prerequisites []string `yaml:"prerequisites"`
+	SaveUrl       string   `yaml:"save_url"`
 }
 
 type Stackerfile struct {
@@ -455,6 +456,7 @@ func NewStackerfile(stackerfile string, substitutions []string) (*Stackerfile, e
 	sf.fileOrder = []string{}      // Order of layers
 	sf.buildConfig = &BuildConfig{ // Stacker build configuration
 		Prerequisites: []string{},
+		SaveUrl:       "",
 	}
 	lms := yaml.MapSlice{} // Actual list of layers excluding the stacker_config directive
 	for _, e := range ms {

--- a/base.go
+++ b/base.go
@@ -86,6 +86,7 @@ func importImage(is *ImageSource, config StackerConfig) error {
 		defer oci.Close()
 	}()
 
+	fmt.Printf("loading %s\n", toImport)
 	err = lib.ImageCopy(lib.ImageCopyOpts{
 		Src:      toImport,
 		Dest:     fmt.Sprintf("oci:%s:%s", cacheDir, tag),

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -50,6 +50,10 @@ var buildCmd = cli.Command{
 			Name:  "order-only",
 			Usage: "show the build order without running the actual build",
 		},
+		cli.StringSliceFlag{
+			Name:  "remote-save-tag",
+			Usage: "tag to be used with --remote-save",
+		},
 	},
 	Before: beforeBuild,
 }
@@ -88,6 +92,7 @@ func doBuild(ctx *cli.Context) error {
 		OnRunFailure:            ctx.String("on-run-failure"),
 		ApplyConsiderTimestamps: ctx.Bool("apply-consider-timestamps"),
 		LayerType:               ctx.String("layer-type"),
+		RemoteSaveTags:          ctx.StringSlice("remote-save-tag"),
 		OrderOnly:               ctx.Bool("order-only"),
 		Debug:                   debug,
 	}

--- a/git.go
+++ b/git.go
@@ -1,30 +1,73 @@
 package stacker
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 )
 
-// Git version generates a version string similar to what git describe --always
+// gitHash generates a version string similar to git describe --always
+func gitHash(path string, short bool) (string, error) {
+
+	// Get hash
+	args := []string{"-C", path, "rev-parse", "HEAD"}
+	if short {
+		args = []string{"-C", path, "rev-parse", "--short", "HEAD"}
+	}
+	output, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GitVersion generates a version string similar to what git describe --always
 // does, with -dirty on the end if the git repo had local changes.
 func GitVersion(path string) (string, error) {
-	output, err := exec.Command("git", "-C", path, "status", "--porcelain", "--untracked-files=no").CombinedOutput()
+
+	// Obtain commit hash
+	hash, err := gitHash(path, false)
 	if err != nil {
 		return "", err
 	}
 
-	isClean := len(output) == 0
-
-	output, err = exec.Command("git", "-C", path, "rev-parse", "HEAD").CombinedOutput()
+	// Check if there are local changes
+	args := []string{"-C", path, "status", "--porcelain", "--untracked-files=no"}
+	output, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
 		return "", err
 	}
 
-	hash := strings.TrimSpace(string(output))
-
-	if isClean {
+	if len(output) == 0 {
+		// Commit is clean, no local changes found
 		return hash, nil
 	}
 
 	return hash + "-dirty", nil
+}
+
+// NewGitLayerTag version generates a commit-<id> tag to be used for uploading an image to a docker registry
+func NewGitLayerTag(path string) (string, error) {
+
+	// Check if there are local changes
+	args := []string{"-C", path, "status", "--porcelain", "--untracked-files=no"}
+	output, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	// If there are local changes, we don't generate a git commit tag for the new layer
+	if len(output) != 0 {
+		return "", fmt.Errorf("commit is dirty so don't generate a tag based on git commit: %s", output)
+	}
+
+	// Determine git hash
+	hash, err := gitHash(path, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Add commit id in tag
+	return "commit-" + hash, nil
 }

--- a/test/save.bats
+++ b/test/save.bats
@@ -1,0 +1,135 @@
+load helpers
+
+function setup() {
+    cleanup
+    rm -rf ocibuilds || true
+    rm -rf oci_save || true
+    rm -rf /tmp/ocibuilds || true
+    mkdir -p ocibuilds/sub1
+    mkdir oci_save
+    touch ocibuilds/sub1/import1
+    cat > ocibuilds/sub1/stacker.yaml <<EOF
+layer1:
+    from:
+        type: docker
+        url: docker://centos:latest
+    import:
+        - import1
+    run: |
+        cp /stacker/import1 /root/import1
+EOF
+    mkdir -p ocibuilds/sub2
+    touch ocibuilds/sub2/import2
+    cat > ocibuilds/sub2/stacker.yaml <<EOF
+stacker_config:
+    prerequisites:
+        - ../sub1/stacker.yaml
+    save_url: oci:oci_save
+layer2:
+    from:
+        type: built
+        tag: layer1
+    import:
+        - import2
+    run: |
+        cp /stacker/import2 /root/import2
+        cp /root/import1 /root/import1_copied
+EOF
+    mkdir -p ocibuilds/sub3
+    cat > ocibuilds/sub3/stacker.yaml <<EOF
+stacker_config:
+    prerequisites:
+        - ../sub2/stacker.yaml
+    save_url: oci:oci_save
+layer3:
+    from:
+        type: built
+        tag: layer2
+    run: |
+        cp /root/import2 /root/import2_copied
+EOF
+    mkdir -p /tmp/ocibuilds/sub4
+    cat > /tmp/ocibuilds/sub4/stacker.yaml <<EOF
+stacker_config:
+    save_url: oci:oci_save
+layer4:
+    from:
+        type: docker
+        url: docker://centos:latest
+    run: |
+        ls > /root/ls_out
+EOF
+}
+
+function teardown() {
+    cleanup
+    rm -rf ocibuilds || true
+    rm -rf /tmp/ocibuilds || true
+    rm -rf oci_save || true
+}
+
+@test "build layers and save them" {
+    stacker build -f ocibuilds/sub3/stacker.yaml
+
+    # Determine expected commit hash
+    commit_hash=commit-$(git rev-parse --short HEAD)
+    echo ${commit_hash}
+
+    if [[ -z $(git status --porcelain --untracked-files=no) ]]; then
+        # Unpack saved image and check content
+        mkdir dest
+        umoci unpack --image oci_save:layer2_${commit_hash} dest/layer2
+        [ -f dest/layer2/rootfs/root/import2 ]
+        [ -f dest/layer2/rootfs/root/import1_copied ]
+        [ -f dest/layer2/rootfs/root/import1 ]
+        umoci unpack --image oci_save:layer3_${commit_hash} dest/layer3
+        [ -f dest/layer3/rootfs/root/import2_copied ]
+        [ -f dest/layer3/rootfs/root/import2 ]
+        [ -f dest/layer3/rootfs/root/import1_copied ]
+        [ -f dest/layer3/rootfs/root/import1 ]
+    else
+        [[ "${output}" =~ ^(.*can\'t save layer layer2 since list of tags is empty)$ ]]
+        [[ "${output}" =~ ^(.*can\'t save layer layer3 since list of tags is empty)$ ]]
+    fi
+}
+
+@test "build layer and save it with custom tags" {
+    stacker build -f ocibuilds/sub2/stacker.yaml --remote-save-tag test1 --remote-save-tag test2
+
+    # Determine expected commit hash
+    commit_hash=commit-$(git rev-parse --short HEAD)
+    echo ${commit_hash}
+
+    # Unpack saved image and check content
+    mkdir dest
+    if [[ -z $(git status --porcelain --untracked-files=no) ]]; then
+        umoci unpack --image oci_save:layer2_${commit_hash} dest/layer2_commit
+        [ -f dest/layer2_commit/rootfs/root/import2 ]
+        [ -f dest/layer2_commit/rootfs/root/import1_copied ]
+        [ -f dest/layer2_commit/rootfs/root/import1 ]
+    else
+        saved=$(umoci list --layout oci_save)
+        [[ ! "${saved}" =~ ^(.*commit-.*)$ ]]
+    fi
+    umoci unpack --image oci_save:layer2_test1 dest/layer2_test1
+    [ -f dest/layer2_test1/rootfs/root/import2 ]
+    [ -f dest/layer2_test1/rootfs/root/import1_copied ]
+    [ -f dest/layer2_test1/rootfs/root/import1 ]
+    umoci unpack --image oci_save:layer2_test2 dest/layer2_test2
+    [ -f dest/layer2_test2/rootfs/root/import2 ]
+    [ -f dest/layer2_test2/rootfs/root/import1_copied ]
+    [ -f dest/layer2_test2/rootfs/root/import1 ]
+}
+
+@test "build layer and save it without git tags" {
+    stacker build -f /tmp/ocibuilds/sub4/stacker.yaml --remote-save-tag test1
+
+    # Check absence of layer with commit in name
+    saved=$(umoci list --layout oci_save)
+    [[ ! "${saved}" =~ ^(.*commit-.*)$ ]]
+
+    # Unpack saved image and check content
+    mkdir dest
+    umoci unpack --image oci_save:layer4_test1 dest/layer4_test1
+    [ -f dest/layer4_test1/rootfs/root/ls_out ]
+}


### PR DESCRIPTION
Feature can be useful if the remote is a docker registry, but can also work with an OCI layout as "remote".
Using an OCI layout is currently useful for testing purposes.