### PR TITLE
Stacker should do a HTTP HEAD call check the Content-Length and X-Checksum-Sha256 of the files imported using HTTP.

### DIFF
--- a/network.go
+++ b/network.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/cheggaaa/pb"
 )
@@ -13,20 +16,55 @@ import (
 // download with caching support in the specified cache dir.
 func Download(cacheDir string, url string) (string, error) {
 	name := path.Join(cacheDir, path.Base(url))
-	out, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		// It already exists, let's just use that one.
-		if os.IsExist(err) {
-			fmt.Println("using cached copy of", url)
-			return name, nil
-		} else if os.IsNotExist(err) {
-			out, err = os.OpenFile(name, os.O_RDWR, 0644)
-			if err != nil {
-				return "", err
-			}
-		} else {
+
+	if fi, err := os.Stat(name); err == nil {
+		// File is found in cache
+		// need to check if cache is valid before using it
+		localHash, err := hashFile(name, false)
+		if err != nil {
 			return "", err
 		}
+		localHash = strings.TrimPrefix(localHash, "sha256:")
+		localSize := strconv.FormatInt(fi.Size(), 10)
+		fmt.Printf("Local file: hash: %s length: %s\n", localHash, localSize)
+
+		remoteHash, remoteSize, err := getHttpFileInfo(url)
+		if err != nil {
+			// Needed for "working offline"
+			// See https://github.com/anuvu/stacker/issues/44
+			fmt.Println("cannot obtain file info of", url)
+			fmt.Println("using cached copy of", url)
+			return name, nil
+		}
+		fmt.Printf("Remote file: hash: %s length: %s\n", remoteHash, remoteSize)
+
+		if localHash == remoteHash {
+			// Cached file has same hash as the remote file
+			fmt.Println("matched hash of", url)
+			fmt.Println("using cached copy of", url)
+			return name, nil
+		} else if localSize == remoteSize {
+			// Cached file has same content length as the remote file
+			fmt.Println("matched content length of", url)
+			fmt.Println("taking a leap of faith using cached copy of", url)
+			return name, nil
+		}
+		// Cached file has a different hash from the remote one
+		// Need to cleanup
+		err = os.RemoveAll(name)
+		if err != nil {
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		// File is not found in cache but there are other errors
+		return "", err
+	}
+
+	// File is not in cache
+	// it wasn't there in the first place or it was cleaned up
+	out, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return "", err
 	}
 	defer out.Close()
 
@@ -56,4 +94,31 @@ func Download(cacheDir string, url string) (string, error) {
 
 	_, err = io.Copy(out, source)
 	return name, err
+}
+
+// getHttpFileInfo returns the hash and content size a file stored on a web server
+func getHttpFileInfo(remoteURL string) (string, string, error) {
+
+	// Verify URL scheme
+	u, err := url.Parse(remoteURL)
+	if err != nil {
+		return "", "", err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", "", fmt.Errorf("cannot obtain content info for non HTTP URL: (%s)", remoteURL)
+	}
+
+	// Make a HEAD call on remote URL
+	resp, err := http.Head(remoteURL)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	// Get file info from header
+	// If the hash is not present this is an empty string
+	hash := resp.Header.Get("X-Checksum-Sha256")
+	length := resp.Header.Get("Content-Length")
+
+	return hash, length, nil
 }

--- a/test/import-http.bats
+++ b/test/import-http.bats
@@ -1,0 +1,76 @@
+load helpers
+
+function teardown() {
+    cleanup
+    rm -rf img || true
+    rm -rf reference || true
+    rm -rf dest || true
+    sudo ip netns del stacker-test || true
+}
+
+function setup() {
+    mkdir reference
+    mkdir dest
+    rm -f nm_orig
+    wget http://network-test.debian.org/nm -O reference/nm_orig
+    mkdir img
+    sudo ip netns add stacker-test
+    # Need to separate layer download from the download of the test file for imports
+    # As we want to be able to have network for base image download
+    # in img/stacker1.yaml but disconnect the network for test file download
+    cat > img/stacker1.yaml <<EOF
+centos_base:
+    from:
+        type: docker
+        url: docker://centos:latest
+    run: |
+        ls
+EOF
+    cat > img/stacker2.yaml <<EOF
+img:
+    from:
+        type: oci
+        url: $(pwd)/oci:centos_base
+    import:
+        - http://network-test.debian.org/nm
+    run: |
+        cp /stacker/nm /root/nm
+EOF
+}
+
+@test "importing from cache works for unreachable http urls" {
+    # Build base image
+    stacker build -f img/stacker1.yaml
+    umoci ls --layout oci
+    # First execution creates the cache
+    stacker build -f img/stacker2.yaml
+    umoci ls --layout oci
+    # Second execution reads from the cache, but cannot access the net
+    run ip netns exec stacker-test "${ROOT_DIR}/stacker" build -f img/stacker2.yaml
+    [ "$status" -eq 0 ]
+    [[ ${output} =~ "cannot obtain file info of" ]]
+    [[ ${output} =~ "using cached copy of" ]]
+    umoci ls --layout oci
+    umoci unpack --image oci:img dest/img
+    [ "$(sha reference/nm_orig)" == "$(sha .stacker/imports/img/nm)" ]
+    [ "$(sha reference/nm_orig)" == "$(sha dest/img/rootfs/root/nm)" ]
+}
+
+@test "importing cached file from http url with matching lenght" {
+    # Build base image
+    stacker build -f img/stacker1.yaml
+    umoci ls --layout oci
+    # First execution creates the cache
+    stacker build -f img/stacker2.yaml
+    umoci ls --layout oci
+    # Second execution reads from the cache
+    stacker build -f img/stacker2.yaml
+    umoci ls --layout oci
+    [[ ${output} =~ "matched content length of" ]]
+    [[ ${output} =~ "taking a leap of faith using cached copy of" ]]
+    umoci unpack --image oci:img dest/img
+    [ "$(sha reference/nm_orig)" == "$(sha .stacker/imports/img/nm)" ]
+    [ "$(sha reference/nm_orig)" == "$(sha dest/img/rootfs/root/nm)" ]
+}
+
+# Ideally there would tests to hit/miss cache for servers which provide a hash


### PR DESCRIPTION
Fix for https://github.com/anuvu/stacker/issues/44
    
    There are several cases:
    - If the file is not in cache download it - covered by tests
    - If the file is in cache but there's an error connecting to the server skip the download - covered by tests
    - If the file is in cache and the shasum is present in HTTP head and matching the file cached locally skip the download - NOT covered by tests
    - If the file is in cache and the content length in HTTP head matches the size of the file cached locally skip the download - covered by tests
    - If the file is in cache and both the shasum and the content length are different from the file cached locally download the file - NOT covered by tests

