### PR TITLE
Use git describe to calculate a version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 GO_SRC=$(shell find . -name \*.go)
-COMMIT_HASH=$(shell git rev-parse HEAD)
-COMMIT=$(if $(shell git status --porcelain --untracked-files=no),$(COMMIT_HASH)-dirty,$(COMMIT_HASH))
+VERSION=$(shell git describe --tags || git rev-parse HEAD)
+VERSION_FULL=$(if $(shell git status --porcelain --untracked-files=no),$(VERSION)-dirty,$(VERSION))
 TEST?=$(patsubst test/%.bats,%,$(wildcard test/*.bats))
 
 stacker: $(GO_SRC)
-	go build -ldflags "-X main.version=$(COMMIT)" -o stacker ./cmd
+	go build -ldflags "-X main.version=$(VERSION_FULL)" -o stacker ./cmd
 
 # make test TEST=basic will run only the basic test.
 .PHONY: check


### PR DESCRIPTION
Rather than spitting out a version that is simply a commit hash,
use output from git-describe.

Before:
  $ stacker --version
  stacker version 982c0032ce1a2cebf45d31904d920f20cabaa549

After
  $ stacker --version
  stacker version v0.4.0-78-gb16a7a1
