### PR TITLE
In case of build-only layers, look for base layers in OCIDir before looking into layer-bases

### DIFF
--- a/base.go
+++ b/base.go
@@ -366,6 +366,17 @@ func getBuilt(o BaseLayerOpts, sfm StackerFiles) error {
 		// it was sourced from e.g. a tar file, in which case there's
 		// nothing we can do besides initialize an empty oci tag and
 		// generate the whole thing.
+
+		// Attempt to copy the base from o.Config.OCIDir layout in case it's already there
+		err = lib.ImageCopy(lib.ImageCopyOpts{
+			Src:  fmt.Sprintf("oci:%s:%s", o.Config.OCIDir, baseInputTag),
+			Dest: fmt.Sprintf("oci:%s:%s", o.Config.OCIDir, targetName),
+		})
+		if err == nil {
+			return nil
+		}
+
+		// Attempt to copy the base from the layer-bases layout
 		cacheDir := path.Join(o.Config.StackerDir, "layer-bases", "oci")
 		err = lib.ImageCopy(lib.ImageCopyOpts{
 			Src:  fmt.Sprintf("oci:%s:%s", cacheDir, baseInputTag),

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -126,3 +126,32 @@ function teardown() {
     [ -f dest/layer3_2/rootfs/root/import0_copied ]
     [ -f dest/layer3_2/rootfs/root/import0 ]
 }
+
+@test "build layers and prerequisites containing build-only layer" {
+    mkdir -p ocibuilds/sub4
+    cat > ocibuilds/sub4/stacker.yaml <<EOF
+config:
+    prerequisites:
+        - ../sub1/stacker.yaml
+layer4_1:
+    from:
+        type: built
+        tag: layer1_2
+    run: |
+        touch /root/import4
+    build_only: true
+layer4_2:
+    from:
+        type: built
+        tag: layer4_1
+    run: |
+        cp /root/import4 /root/import4_copied
+EOF
+    stacker build -f ocibuilds/sub4/stacker.yaml
+    mkdir dest
+    umoci unpack --image oci:layer4_2 dest/layer4_2
+    [ "$status" -eq 0 ]
+    [ -f dest/layer4_2/rootfs/root/import4_copied ]
+    [ -f dest/layer4_2/rootfs/root/import4 ]
+    [ -f dest/layer4_2/rootfs/root/import0 ]
+}


### PR DESCRIPTION
Fix bug introduced in: https://github.com/anuvu/stacker/commit/dce7c10c86b4c67f5cd54ce2c7e8da43227420c1
If a build-only layer depended on a non-build-only layer which was previously built (not downloaded), it would try to copy the base image from 'layer-bases' instead of the OCIDir where stacker places it