### PR TITLE
Read config from ~/.config/stacker/conf.yaml not ~/.config/conf.yaml.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,11 +27,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	configDir := os.Getenv("XDG_CONFIG_HOME")
-	if configDir == "" {
-		configDir = path.Join(user.HomeDir, ".config")
-	}
-
 	app := cli.NewApp()
 	app.Name = "stacker"
 	app.Usage = "stacker builds OCI images"
@@ -48,6 +43,11 @@ func main() {
 		umociCmd,
 		unprivSetupCmd,
 		gcCmd,
+	}
+
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+	if configDir == "" {
+		configDir = path.Join(user.HomeDir, ".config", app.Name)
 	}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
I'm pretty sure this was just a bug that had stacker reading its
config file from the dubiously named ~/.config/conf.yaml.

Fixed here to now read ~/.config/stacker/conf.yaml.