### PR TITLE
Send some status/warning messages to stderr in the chroot path.

### DIFF
--- a/api.go
+++ b/api.go
@@ -442,7 +442,7 @@ func substitute(content string, substitutions []string) (string, error) {
 		from := fmt.Sprintf("$%s", membs[0])
 		to := membs[1]
 
-		fmt.Printf("substituting %s to %s\n", from, to)
+		fmt.Fprintf(os.Stderr, "substituting %s to %s\n", from, to)
 
 		content = strings.Replace(content, from, to, -1)
 

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -63,7 +63,7 @@ func doChroot(ctx *cli.Context) error {
 	file := ctx.String("f")
 	sf, err := stacker.NewStackerfile(file, ctx.StringSlice("substitute"))
 	if err != nil {
-		fmt.Printf("couldn't find stacker file, chrooting to %s as best effort\n", tag)
+		fmt.Fprintf(os.Stderr, "couldn't find stacker file, chrooting to %s as best effort\n", tag)
 		return stacker.Run(config, tag, cmd, &stacker.Layer{}, "", os.Stdin)
 	}
 
@@ -78,6 +78,6 @@ func doChroot(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Println("WARNING: this chroot is temporary, any changes will be destroyed when it exits.")
+	fmt.Fprintln(os.Stderr, "WARNING: this chroot is temporary, any changes will be destroyed when it exits.")
 	return stacker.Run(config, tag, cmd, layer, "", os.Stdin)
 }


### PR DESCRIPTION
I was wanting to do something like:
 stacker chroot thing cat /etc/passwd > out

and the output would have warnings and "substituting" messages.
The solution here is just to very minimally get *those* messages
to stderr.