### PR TITLE
import: remove the proper path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST?=$(patsubst test/%.bats,%,$(wildcard test/*.bats))
 stacker: $(GO_SRC)
 	go build -ldflags "-X main.version=$(VERSION_FULL)" -o stacker ./cmd
 
-# make test TEST=basic will run only the basic test.
+# make check TEST=basic will run only the basic test.
 .PHONY: check
 check: stacker
 	go fmt ./... && ([ -z $(TRAVIS) ] || git diff --quiet)

--- a/import.go
+++ b/import.go
@@ -120,9 +120,9 @@ func importFile(imp string, cacheDir string) (string, error) {
 	for _, d := range diff {
 		switch d.Type() {
 		case mtree.Missing:
-			err := os.RemoveAll(path.Join(cacheDir, d.Path()))
+			err := os.RemoveAll(path.Join(cacheDir, path.Base(imp), d.Path()))
 			if err != nil {
-				return "", errors.Wrapf(err, "couldn't remove missing import %s", path.Join(cacheDir, d.Path()))
+				return "", errors.Wrapf(err, "couldn't remove missing import %s", path.Join(cacheDir, path.Base(imp), d.Path()))
 			}
 		case mtree.Modified:
 			fallthrough

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -54,12 +54,10 @@ a:
     import:
         - foo
     run: |
-        [ -f /stacker/foo/baz ]
+        [ ! -f /stacker/foo/bar ]
 EOF
     rm foo/bar
-    touch foo/baz
     stacker build
-    [ "$status" -eq 0 ]
 }
 
 @test "bind rebuilds" {

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -10,7 +10,7 @@ function teardown() {
 import-cache:
     from:
         type: docker
-        url: docker://centos:latest
+        url: docker://alpine:latest
     import:
         - link/foo
     run: cp /stacker/foo/zomg /zomg
@@ -34,7 +34,7 @@ EOF
 a:
     from:
         type: docker
-        url: docker://centos:latest
+        url: docker://alpine:latest
     import:
         - foo
     run: |
@@ -50,7 +50,7 @@ EOF
 a:
     from:
         type: docker
-        url: docker://centos:latest
+        url: docker://alpine:latest
     import:
         - foo
     run: |
@@ -67,7 +67,7 @@ EOF
 bind-test:
     from:
         type: docker
-        url: docker://centos:latest
+        url: docker://alpine:latest
     import:
         - tree1/foo/zomg
     binds:
@@ -104,7 +104,7 @@ EOF
 mode-test:
     from:
         type: docker
-        url: docker://centos:latest
+        url: docker://alpine:latest
     import:
         - executable
     run: cp /stacker/executable /executable


### PR DESCRIPTION
Closes #70

When a file under an imported directory is removed, calculate the
correct path to remove.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>