### PR TITLE
Only print an error if there was an error

### DIFF
--- a/container.go
+++ b/container.go
@@ -43,7 +43,9 @@ func init() {
 		// re-execing inside a user namespace we don't want to do that.
 		// So let's just ignore the error and let future code handle it.
 		IdmapSet, err = idmap.DefaultIdmapSet("", currentUser.Username)
-		log.Warnf("failed parsing /etc/sub{u,g}idmap: %v", err)
+		if err != nil {
+			log.Warnf("failed parsing /etc/sub{u,g}idmap: %v", err)
+		}
 
 		if IdmapSet != nil {
 			/* Let's make our current user the root user in the ns, so that when


### PR DESCRIPTION
Fix an error in my last patch which causes us to always print something
like

2020/02/14 22:38:37  warn failed parsing /etc/sub{u,g}idmap: <nil>

Signed-off-by: Serge Hallyn <shallyn@cisco.com>