### PR TITLE
Allow substitutions from stacker config into a stacker.yaml

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,6 +31,15 @@ type StackerConfig struct {
 	RootFSDir  string `yaml:"rootfs_dir"`
 }
 
+// Substitutions - return an array of substitutions for StackerFiles
+func (sc *StackerConfig) Substitutions() []string {
+	return []string{
+		fmt.Sprintf("STACKER_ROOTFS_DIR=%s", sc.RootFSDir),
+		fmt.Sprintf("STACKER_STACKER_DIR=%s", sc.StackerDir),
+		fmt.Sprintf("STACKER_OCI_DIR=%s", sc.OCIDir),
+	}
+}
+
 type BuildConfig struct {
 	Prerequisites []string `yaml:"prerequisites"`
 }

--- a/build.go
+++ b/build.go
@@ -195,7 +195,8 @@ func (b *Builder) Build(file string) error {
 		os.RemoveAll(opts.Config.StackerDir)
 	}
 
-	sf, err := NewStackerfile(file, opts.Substitute)
+	fmt.Printf("Build subs: %v\n", b.opts.Config.Substitutions())
+	sf, err := NewStackerfile(file, append(opts.Substitute, b.opts.Config.Substitutions()...))
 	if err != nil {
 		return err
 	}
@@ -597,7 +598,7 @@ func (b *Builder) BuildMultiple(paths []string) error {
 	opts := b.opts
 
 	// Read all the stacker recipes
-	stackerFiles, err := NewStackerFiles(paths, opts.Substitute)
+	stackerFiles, err := NewStackerFiles(paths, append(opts.Substitute, b.opts.Config.Substitutions()...))
 	if err != nil {
 		return err
 	}

--- a/publisher.go
+++ b/publisher.go
@@ -171,7 +171,7 @@ func (p *Publisher) PublishMultiple(paths []string) error {
 func (p *Publisher) readStackerFiles(paths []string) (StackerFiles, error) {
 
 	// Read all the stacker recipes
-	sfm, err := NewStackerFiles(paths, p.opts.Substitute)
+	sfm, err := NewStackerFiles(paths, append(p.opts.Substitute, p.opts.Config.Substitutions()...))
 	if err != nil {
 
 		// Verify if the error is related to an invalid substitution


### PR DESCRIPTION
This allows the stacker.yaml to reference stacker config.
It allows substitutions of:

   STACKER_ROOTFS_DIR  RootFSDir
   STACKER_STACKER_DIR StackerDir
   STACKER_OCI_DIR     OCIDir