### PR TITLE
Add Config-value documentation and a test. Remove an inadvertant printf.

### DIFF
--- a/build.go
+++ b/build.go
@@ -195,7 +195,6 @@ func (b *Builder) Build(file string) error {
 		os.RemoveAll(opts.Config.StackerDir)
 	}
 
-	fmt.Printf("Build subs: %v\n", b.opts.Config.Substitutions())
 	sf, err := NewStackerfile(file, append(opts.Substitute, b.opts.Config.Substitutions()...))
 	if err != nil {
 		return err

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -16,6 +16,14 @@ with `${FOO:default}` a default value will evaluate to their default if not
 specified on the command line. It is an error to specify a `${FOO}` style
 without a default; to make the default an empty string, use `${FOO:}`.
 
+In addition to substitutions provided on the command line, the following
+variables are also available with their values from either command
+line flags or stacker-config file.
+
+    STACKER_STACKER_DIR config name 'stacker_dir', cli flag '--stacker-dir'-
+    STACKER_ROOTFS_DIR  config name 'rootfs_dir', cli flag '--roots-dir'
+    STACKER_OCI_DIR     config name 'oci_dir', cli flag '--oci-dir'
+
 #### `from`
 
 The `from` directive describes the base image that stacker will start from. It

--- a/test/config.bats
+++ b/test/config.bats
@@ -2,39 +2,42 @@ load helpers
 
 function teardown() {
     cleanup
-    umount args-roots || true
-    umount config-roots || true
-    rm -rf *-oci *-stacker *-roots config.yaml || true
+    rm -rf *-oci *-stacker *-roots || true
 }
 
 @test "config args work" {
+    TEST_TMPDIR=$(tmpd config-args)
+    local tmpd="$TEST_TMPDIR"
     cat > stacker.yaml <<EOF
 test:
     from:
         type: scratch
 EOF
 
-    stacker --oci-dir args-oci --stacker-dir args-stacker --roots-dir args-roots build --leave-unladen
-    [ -d args-oci ]
-    [ -d args-stacker ]
-    [ -d args-roots ]
+    stacker "--oci-dir=$tmpd/args-oci" "--stacker-dir=$tmpd/args-stacker" \
+        "--roots-dir=$tmpd/args-roots" build --leave-unladen
+    [ -d "$tmpd/args-oci" ]
+    [ -d "$tmpd/args-stacker" ]
+    [ -d "$tmpd/args-roots" ]
 }
 
 @test "config file works" {
+    TEST_TMPDIR=$(tmpd config-file)
+    local tmpd="$TEST_TMPDIR"
     cat > stacker.yaml <<EOF
 test:
     from:
         type: scratch
 EOF
-    cat > config.yaml <<EOF
-stacker_dir: config-stacker
-oci_dir: config-oci
-rootfs_dir: config-roots
+    cat > "$tmpd/config.yaml" <<EOF
+stacker_dir: $tmpd/config-stacker
+oci_dir: $tmpd/config-oci
+rootfs_dir: $tmpd/config-roots
 EOF
 
-    stacker --config config.yaml build --leave-unladen
+    stacker "--config=$tmpd/config.yaml" build --leave-unladen
     ls
-    [ -d config-oci ]
-    [ -d config-stacker ]
-    [ -d config-roots ]
+    [ -d "$tmpd/config-oci" ]
+    [ -d "$tmpd/config-stacker" ]
+    [ -d "$tmpd/config-roots" ]
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -41,3 +41,56 @@ EOF
     [ -d "$tmpd/config-stacker" ]
     [ -d "$tmpd/config-roots" ]
 }
+
+@test "config file substitutions work" {
+    # the stacker file provided runs a 'my-build' that creates /my-publish/output.tar
+    # output.tar's content.txt file should have the rendered values
+    # for STACKER_ROOTFS_DIR STACKER_OCI_DIR and STACKER_STACKER_DIR
+    #
+    # my-base then imports that output file using the expansion of STACKER_ROOTFS_DIR.
+    # the test compares that the rootfs from my-base contains the expected content.txt.
+    TEST_TMPDIR=$(tmpd config-subs)
+    local tmpd="${TEST_TMPDIR}"
+    local sdir="$tmpd/stacker.d" odir="$tmpd/oci.d" rdir="$tmpd/roots.d"
+    local stacker_yaml="$tmpd/stacker.yaml" config_yaml="$tmpd/config.yaml"
+    local expected="$tmpd/expected.txt"
+
+    printf "%s\n%s\n%s\n" \
+        "found rootfs=$rdir" "found oci=$odir" "found stacker=$sdir" > "$expected"
+
+    cat > "$stacker_yaml" <<"EOF"
+my-build:
+    build_only: true
+    from:
+        type: docker
+        url: docker://centos:latest
+    run: |
+        #!/bin/sh
+        set -e
+        outd=/my-publish
+        rm -Rf "$outd"
+        mkdir -p "$outd"
+        cd "$outd"
+        cat > content.txt <<EOF
+        found rootfs=${{STACKER_ROOTFS_DIR}}
+        found oci=${{STACKER_OCI_DIR}}
+        found stacker=${{STACKER_STACKER_DIR}}
+        EOF
+        tar -cf output.tar content.txt
+
+my-base:
+    from:
+        type: tar
+        url: ${{STACKER_ROOTFS_DIR}}/my-build/rootfs/my-publish/output.tar
+EOF
+
+    cat > "$config_yaml" <<EOF
+stacker_dir: $sdir
+oci_dir: $odir
+rootfs_dir: $rdir
+EOF
+
+    stacker "--config=$config_yaml" build "--stacker-file=$stacker_yaml" --leave-unladen
+
+    cmp_files "$expected" "$rdir/my-base/rootfs/content.txt"
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -75,3 +75,17 @@ function umount_under() {
     done
     return 0
 }
+
+function cmp_files() {
+    local f1="$1" f2="$2" f1sha="" f2sha=""
+    [ -f "$f1" ] || { stderr "$f1: not a file"; return 1; }
+    [ -f "$f2" ] || { stderr "$f2: not a file"; return 1; }
+    f1sha=$(sha "$f1") || { stderr "failed sha $f1"; return 1; }
+    f2sha=$(sha "$f2") || { stderr "failed sha $f2"; return 1; }
+    if [ "$f1sha" != "$f2sha" ]; then
+        stderr "$f1 and $f2 differed"
+        diff -u "$f1" "$f2" 1>&2 || :
+        return 1
+    fi
+    return 0
+}


### PR DESCRIPTION
Follow on to #78 to:
   - Remove debug Printf.
   - Add test for config substitutions.
   - Add some helpers for tests (umount_under, stderr, tmpd, cmp_files)
   - Add some doc for config file substitutions.