### PR TITLE
Add STACKER_LAYER_NAME to the name of the layer to a build environment.

### DIFF
--- a/build.go
+++ b/build.go
@@ -217,7 +217,7 @@ func (b *Builder) Build(file string) error {
 		}
 		defer c.Close()
 
-		err = c.SetupLayerConfig(l)
+		err = c.SetupLayerConfig(l, name)
 		if err != nil {
 			return err
 		}

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -94,7 +94,7 @@ func doChroot(ctx *cli.Context) error {
 		return err
 	}
 	defer c.Close()
-	err = c.SetupLayerConfig(layer)
+	err = c.SetupLayerConfig(layer, name)
 	if err != nil {
 		return err
 	}

--- a/container.go
+++ b/container.go
@@ -276,8 +276,8 @@ func (c *Container) Execute(args string, stdin io.Reader) error {
 	return c.containerError(cmdErr, "execute failed")
 }
 
-func (c *Container) SetupLayerConfig(l *types.Layer) error {
-	env, err := l.BuildEnvironment()
+func (c *Container) SetupLayerConfig(l *types.Layer, name string) error {
+	env, err := l.BuildEnvironment(name)
 	if err != nil {
 		return err
 	}

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -24,6 +24,18 @@ line flags or stacker-config file.
     STACKER_ROOTFS_DIR  config name 'rootfs_dir', cli flag '--roots-dir'
     STACKER_OCI_DIR     config name 'oci_dir', cli flag '--oci-dir'
 
+
+The stacker build environment will have the following environment variables
+available for reference:
+
+  * `STACKER_LAYER_NAME`: the name of the layer being built.  `STACKER_LAYER_NAME`
+    will be `my-build` when the `run` section below is executed.
+
+      ```yaml
+      my-build:
+        run: echo "Your layer is ${STACKER_LAYER_NAME}"
+      ```
+
 #### `from`
 
 The `from` directive describes the base image that stacker will start from. It

--- a/test/config.bats
+++ b/test/config.bats
@@ -59,8 +59,9 @@ EOF
     local stacker_yaml="$tmpd/stacker.yaml" config_yaml="$tmpd/config.yaml"
     local expected="$tmpd/expected.txt"
 
-    printf "%s\n%s\n%s\n" \
-        "found rootfs=$rdir" "found oci=$odir" "found stacker=$sdir" > "$expected"
+    printf "%s\n%s\n%s\n%s\n" \
+        "found rootfs=$rdir" "found oci=$odir" "found stacker=$sdir" \
+        "found name=my-build" > "$expected"
 
     cat > "$stacker_yaml" <<"EOF"
 my-build:
@@ -79,6 +80,7 @@ my-build:
         found rootfs=${{STACKER_ROOTFS_DIR}}
         found oci=${{STACKER_OCI_DIR}}
         found stacker=${{STACKER_STACKER_DIR}}
+        found name=my-build
         EOF
         tar -cf output.tar content.txt
 

--- a/types/layer.go
+++ b/types/layer.go
@@ -37,7 +37,6 @@ type Layer struct {
 	Binds              interface{}       `yaml:"binds"`
 	Apply              []string          `yaml:"apply"`
 	RuntimeUser        string            `yaml:"runtime_user"`
-	Name               string            // the name of this layer in the stacker file.
 	referenceDirectory string            // Location of the directory where the layer is defined
 }
 
@@ -93,9 +92,9 @@ func buildEnv(passThrough []string, newEnv map[string]string,
 	return ret, nil
 }
 
-func (l *Layer) BuildEnvironment() (map[string]string, error) {
+func (l *Layer) BuildEnvironment(name string) (map[string]string, error) {
 	env, err := buildEnv(l.BuildEnvPt, l.BuildEnv, os.Environ)
-	env["STACKER_LAYER_NAME"] = l.Name
+	env["STACKER_LAYER_NAME"] = name
 	return env, err
 }
 

--- a/types/layer.go
+++ b/types/layer.go
@@ -37,6 +37,7 @@ type Layer struct {
 	Binds              interface{}       `yaml:"binds"`
 	Apply              []string          `yaml:"apply"`
 	RuntimeUser        string            `yaml:"runtime_user"`
+	Name               string            // the name of this layer in the stacker file.
 	referenceDirectory string            // Location of the directory where the layer is defined
 }
 
@@ -93,7 +94,9 @@ func buildEnv(passThrough []string, newEnv map[string]string,
 }
 
 func (l *Layer) BuildEnvironment() (map[string]string, error) {
-	return buildEnv(l.BuildEnvPt, l.BuildEnv, os.Environ)
+	env, err := buildEnv(l.BuildEnvPt, l.BuildEnv, os.Environ)
+	env["STACKER_LAYER_NAME"] = l.Name
+	return env, err
 }
 
 func (l *Layer) ParseCmd() ([]string, error) {

--- a/types/stackerfile.go
+++ b/types/stackerfile.go
@@ -263,7 +263,6 @@ func NewStackerfile(stackerfile string, substitutions []string) (*Stackerfile, e
 
 		// Set the directory with the location where the layer was defined
 		layer.referenceDirectory = sf.ReferenceDirectory
-		layer.Name = name
 	}
 
 	return &sf, err

--- a/types/stackerfile.go
+++ b/types/stackerfile.go
@@ -263,6 +263,7 @@ func NewStackerfile(stackerfile string, substitutions []string) (*Stackerfile, e
 
 		// Set the directory with the location where the layer was defined
 		layer.referenceDirectory = sf.ReferenceDirectory
+		layer.Name = name
 	}
 
 	return &sf, err


### PR DESCRIPTION
Now a run section will contain an environment variable
STACKER_LAYER_NAME.  The value is the name of the layer section
in the yaml file.

Fixes #95.