### PR TITLE
lib/image: added SkipTLS option for source and destination separately

### DIFF
--- a/base.go
+++ b/base.go
@@ -124,10 +124,10 @@ func importContainersImage(is *types.ImageSource, config types.StackerConfig, pr
 
 	log.Infof("loading %s", toImport)
 	err = lib.ImageCopy(lib.ImageCopyOpts{
-		Src:      toImport,
-		Dest:     fmt.Sprintf("oci:%s:%s", cacheDir, tag),
-		SkipTLS:  is.Insecure,
-		Progress: progressWriter,
+		Src:        toImport,
+		Dest:       fmt.Sprintf("oci:%s:%s", cacheDir, tag),
+		SrcSkipTLS: is.Insecure,
+		Progress:   progressWriter,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "couldn't import base layer %s", tag)

--- a/lib/image.go
+++ b/lib/image.go
@@ -50,7 +50,8 @@ type ImageCopyOpts struct {
 	Dest         string
 	DestUsername string
 	DestPassword string
-	SkipTLS      bool
+	SrcSkipTLS   bool
+	DestSkipTLS  bool
 	Progress     io.Writer
 	Context      context.Context
 }
@@ -83,13 +84,17 @@ func ImageCopy(opts ImageCopyOpts) error {
 		ReportWriter: opts.Progress,
 	}
 
-	if opts.SkipTLS {
+	if opts.SrcSkipTLS {
 		args.SourceCtx = &types.SystemContext{
 			DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
 		}
 	}
 
 	args.DestinationCtx = &types.SystemContext{}
+
+	if opts.DestSkipTLS {
+		args.DestinationCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
 
 	if opts.DestUsername != "" {
 		args.DestinationCtx.DockerAuthConfig = &types.DockerAuthConfig{

--- a/publisher.go
+++ b/publisher.go
@@ -147,7 +147,7 @@ func (p *Publisher) Publish(file string) error {
 					DestUsername: opts.Username,
 					DestPassword: opts.Password,
 					Progress:     progressWriter,
-					SkipTLS:      true,
+					SrcSkipTLS:   true,
 				})
 				if err != nil {
 					return err


### PR DESCRIPTION
1. Add separate options for source and destination skip tls verification. 
2. Since SkipTLS verification was limited to source before, replaced SkipTLS option with SrcSkipTLS option wherever SkipTLS option is set. 