### PR TITLE
tests: actually run unpriv tests again

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -9,8 +9,10 @@ export UBUNTU_OCI="$ROOT_DIR/test/ubuntu:latest"
 
 function skip_if_no_unpriv_overlay {
     [ "$STORAGE_TYPE" == "overlay" ] || return 0
-    run sudo -u $SUDO_USER "${ROOT_DIR}/stacker" umoci check-overlay
-    [ "$status" -eq 0 ] || skip "need newer kernel for unpriv overlay"
+    run sudo -u $SUDO_USER "${ROOT_DIR}/stacker" --debug internal-go testsuite-check-overlay
+    echo $output
+    [ "$status" -eq 50 ] && skip "need newer kernel for unpriv overlay"
+    [ "$status" -eq 0 ]
 }
 
 function sha() {


### PR DESCRIPTION
31c298ee69a3 ("cmd: s/umoci/internal-go") changed the name of the internal
subcommand to umoci, but we didn't notice since we were allowing exit(1) as
an indication that we couldn't do overlayfs.

Instead, let's add an entrypoint to this hidden command that's just for the
testsuite, that tests the environment and exits with a special unused code
if it can't do overlay. This way if we eventually refactor this command
again and break it in the future, it will fail and we'll notice instead of
silently not running the unpriv tests for a while.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>