### PR TITLE
recursive-build, publish: narrow regex for stacker files

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -21,7 +21,7 @@ var publishCmd = cli.Command{
 		cli.StringFlag{
 			Name:  "stacker-file-pattern, p",
 			Usage: "regex pattern to use when searching for stackerfile paths",
-			Value: "stacker.yaml",
+			Value: stackerFilePathRegex,
 		},
 		cli.StringFlag{
 			Name:  "search-dir, d",

--- a/cmd/recursive-build.go
+++ b/cmd/recursive-build.go
@@ -7,6 +7,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+const stackerFilePathRegex = "\\/stacker.yaml$"
+
 var recursiveBuildCmd = cli.Command{
 	Name:   "recursive-build",
 	Usage:  "finds stacker yaml files under a directory and builds all OCI layers they define",
@@ -21,7 +23,7 @@ func initRecursiveBuildFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  "stacker-file-pattern, p",
 			Usage: "regex pattern to use when searching for stackerfile paths",
-			Value: "stacker.yaml",
+			Value: stackerFilePathRegex,
 		},
 		cli.StringFlag{
 			Name:  "search-dir, d",

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -236,3 +236,20 @@ EOF
     umoci unpack --image oci:two dest
     [ -f dest/rootfs/wtf ]
 }
+
+@test "recurisve-build default matching only builds reasonable things" {
+    echo 'this is not valid yaml trolololololo - - - :' > test_stacker.yaml
+    cp test_stacker.yaml .stacker.yaml.swp
+
+    cat > stacker.yaml <<EOF
+one:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+EOF
+
+    stacker recursive-build
+    umoci ls --layout oci
+    # ugh, grep because all the gunk in setup() above needs to move
+    [ "$(umoci ls --layout oci | grep one)" == "one" ]
+}


### PR DESCRIPTION
This regex will match anything containing stacker.yaml, including vim swap
files or things like test_stacker.yaml, which wouldn't be built by the
default "build" command.

Let's change this to match paths that end in /stacker.yaml, which is
probably as close semantically as we can get to the default build command.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>