### PR TITLE
overlay: allow layer collisions

### DIFF
--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -222,6 +222,7 @@ func (o *overlay) Clean() error {
 }
 
 func (o *overlay) GC() error {
+	// see note in pack.go about implementing this
 	return errors.Errorf("todo")
 }
 


### PR DESCRIPTION
See the comments and the tests for cases where this can happen.
Essentially, chained type: built layers with no local changes can end up
generating layers with the same hash (but not always, whee). To fix this,
let's just allow -EEXIST errors from the "metadata syncup" syscalls, and
pretend they were successful.

Ideally, we'd be able to realize we generated this layer previously and
just re-use what we generated. However, this would require some additional
metadata somewhere in order to remember what unchanged built: type layers
we had generated. But that would require more spaghetti in some already
complicated code.

Closes #126

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>