### PR TITLE
overlay: run layer conversion in a userns too

### DIFF
--- a/cmd/internal_go.go
+++ b/cmd/internal_go.go
@@ -132,6 +132,21 @@ var internalGoCmd = cli.Command{
 				},
 			},
 		},
+		cli.Command{
+			Name:   "overlay-convert-and-output",
+			Action: doOverlayConvertAndOutput,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name: "tag",
+				},
+				cli.StringFlag{
+					Name: "name",
+				},
+				cli.StringFlag{
+					Name: "layer-type",
+				},
+			},
+		},
 	},
 	Before: doBeforeUmociSubcommand,
 }
@@ -525,4 +540,12 @@ func doUnpackTar(ctx *cli.Context) error {
 	}
 
 	return layer.UnpackLayer(destDir, uncompressed, &layer.UnpackOptions{KeepDirlinks: true})
+}
+
+func doOverlayConvertAndOutput(ctx *cli.Context) error {
+	tag := ctx.String("tag")
+	name := ctx.String("name")
+	layerType := types.LayerType(ctx.String("layer-type"))
+
+	return overlay.ConvertAndOutput(config, tag, name, layerType)
 }


### PR DESCRIPTION
When using the overlay backend, individual layers are converted from
tar->squashfs when needed (in contrast with btrfs which converts the
underlying image wholesale, preventing sharing of bits). However, this
conversion happened in the host namespace, resulting in invalid images when
used in unprivileged mode.

Let's run this conversion inside a user namespace so we generate valid
images when converting them in this way.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>