### PR TITLE
Support speciying hash of import source, closes #119

### DIFF
--- a/base.go
+++ b/base.go
@@ -37,7 +37,7 @@ func GetBase(o BaseLayerOpts) error {
 			return err
 		}
 
-		_, err := acquireUrl(o.Config, o.Storage, o.Layer.From.Url, cacheDir, o.Progress)
+		_, err := acquireUrl(o.Config, o.Storage, o.Layer.From.Url, cacheDir, o.Progress, "")
 		return err
 	/* now we can do all the containers/image types */
 	case types.OCILayer:

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -84,6 +84,31 @@ will not be reflected.
 
 Will grab /path/to/file from the previously built layer `$name`.
 
+#### `import hash`
+
+The `import` directive also supports specifying the hash(sha256sum) of import source,
+for all the three forms presented above, for example:
+```
+import:
+  - path: config.json
+    hash: f55af805b012017bc....
+  - path: http://example.com/foo.tar.gz
+    hash: b458dfd63e7883a64....
+  - path: stacker://$name/path/to/file
+    hash: f805b012017bc769a....
+```
+Before copying the file it will check if the requested hash matches the actual one.
+This new import mode can be combined with the old one, for example:
+```
+import:
+  - path: "config.json
+    hash: "BEEFcafeaaaaAAAA...."
+  - /path/to/file
+```
+
+
+
+
 #### `environment`, `labels`, `working_dir`, `volumes`, `cmd`, `entrypoint`, `user`
 
 These all correspond exactly to the similarly named bits in the [OCI image

--- a/network.go
+++ b/network.go
@@ -16,10 +16,15 @@ import (
 )
 
 // download with caching support in the specified cache dir.
-func Download(cacheDir string, url string, progress bool) (string, error) {
+func Download(cacheDir string, url string, progress bool, remoteHash string, remoteSize string) (string, error) {
 	name := path.Join(cacheDir, path.Base(url))
 
 	if fi, err := os.Stat(name); err == nil {
+		// Couldn't get remoteHash then use cached copy of import
+		if remoteHash == "" {
+			log.Infof("Couldn't obtain file info of %s, using cached copy", url)
+			return name, nil
+		}
 		// File is found in cache
 		// need to check if cache is valid before using it
 		localHash, err := lib.HashFile(name, false)
@@ -29,15 +34,6 @@ func Download(cacheDir string, url string, progress bool) (string, error) {
 		localHash = strings.TrimPrefix(localHash, "sha256:")
 		localSize := strconv.FormatInt(fi.Size(), 10)
 		log.Debugf("Local file: hash: %s length: %s", localHash, localSize)
-
-		remoteHash, remoteSize, err := getHttpFileInfo(url)
-		if err != nil {
-			// Needed for "working offline"
-			// See https://github.com/anuvu/stacker/issues/44
-			log.Infof("cannot obtain file info of %s, using cached copy", url)
-			return name, nil
-		}
-		log.Debugf("Remote file: hash: %s length: %s", remoteHash, remoteSize)
 
 		if localHash == remoteHash {
 			// Cached file has same hash as the remote file

--- a/test/import.bats
+++ b/test/import.bats
@@ -72,3 +72,95 @@ EOF
 
     stacker build
 }
+
+@test "different import types" {
+    touch test_file
+    test_file_sha=$(sha test_file) || { stderr "failed sha $test_file"; return 1; }
+    touch test_file2
+    cat > stacker.yaml <<EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - path: test_file
+          hash: $test_file_sha
+        - test_file2
+        - https://bing.com/favicon.ico
+    run: |
+        [ -f /stacker/test_file ]
+        [ -f /stacker/test_file2 ]
+        cp /stacker/test_file /test_file
+    build_only: true
+second:
+    from:
+        type: built
+        tag: first
+    import:
+        path: stacker://first/test_file
+        hash: $test_file_sha
+    run: |
+        [ -f /stacker/test_file ]
+EOF
+
+    stacker build
+}
+
+@test "import with unmatched hash should fail" {
+    touch test_file
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - path: test_file
+          hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b856
+EOF
+
+    bad_stacker build
+    echo $output | grep "is different than the actual hash"
+}
+
+@test "invalid hash should fail" {
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - path: test_file
+          hash: 1234abcdef
+EOF
+    bad_stacker build
+    echo $output | grep "is not valid"
+}
+
+@test "case insensitive hash works" {
+    touch test_file
+    test_file_sha=$(sha test_file) || { stderr "failed sha $test_file"; return 1; }
+    test_file_sha_upper=${test_file_sha^^}
+    cat > stacker.yaml <<EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - path: test_file
+          hash: $test_file_sha
+    run: |
+        cp /stacker/test_file /test_file
+    build_only: true
+second:
+    from:
+        type: built
+        tag: first
+    import:
+        path: stacker://first/test_file
+        hash: $test_file_sha_upper
+    run: |
+        [ -f /stacker/test_file ]
+EOF
+
+    stacker build
+}

--- a/types/stackerfile.go
+++ b/types/stackerfile.go
@@ -334,7 +334,7 @@ func (s *Stackerfile) DependencyOrder(sfm StackerFiles) ([]string, error) {
 			// layer which has not been processed
 			allStackerImportsProcessed := true
 			for _, imp := range imports {
-				url, err := NewDockerishUrl(imp)
+				url, err := NewDockerishUrl(imp.Path)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
- supports both imports style:
```
import:
  - path: path/to/file
    hash: sha256sum
  - stacker://first/example.txt
  - http://url/to/file
```