### PR TITLE
ci: fix skopeo install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-20.10
         name: "golang ${{ matrix.go-version }} storage-type ${{ matrix.storage-backend }}"
         strategy:
             matrix:
@@ -23,9 +23,6 @@ jobs:
             - name: install dependencies
               run: |
                   source /etc/os-release
-                  source /etc/os-release && echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /"
-                  source /etc/os-release && sudo -E sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-                  source /etc/os-release && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
                   sudo add-apt-repository -y ppa:ubuntu-lxc/lxc-git-master
                   sudo apt-get update
                   sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev skopeo jq libcap-dev libbtrfs-dev bats parallel


### PR DESCRIPTION
The skopeo install is failing with:

Unpacking containers-common (100:1-7) over (1.2.1~2) ...
dpkg: error processing archive /tmp/apt-dpkg-install-at4ZRl/03-containers-common_100%3a1-7_all.deb (--unpack):
 trying to overwrite '/usr/share/man/man5/containers-auth.json.5.gz', which is also in package containers-image 5.8.1~1

we get our skopeo install from the opensuse build infra for ubuntu, which
is presumably not well maintained :)

In 20.10 it is included in the main ubuntu repos, so let's just get it from
there.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>