### PR TITLE
ci/tests: move away from skopeo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,9 @@ jobs:
             - name: install dependencies
               run: |
                   source /etc/os-release
-                  source /etc/os-release && echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /"
-                  source /etc/os-release && sudo -E sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-                  source /etc/os-release && wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O- | sudo apt-key add -
                   sudo add-apt-repository -y ppa:ubuntu-lxc/lxc-git-master
                   sudo apt-get update
-                  sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev skopeo jq libcap-dev libbtrfs-dev bats parallel
+                  sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev bats parallel
                   GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
                   sudo cp ~/go/bin/umoci /usr/bin
                   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ lint: $(GO_SRC)
 	$(shell go env GOPATH)/bin/golangci-lint run --build-tags "$(BUILD_TAGS)"
 
 check-%: stacker
-	[ -f ./test/centos/index.json ] || skopeo --insecure-policy copy docker://centos:latest oci:./test/centos:latest
-	[ -f ./test/ubuntu/index.json ] || skopeo --insecure-policy copy docker://ubuntu:latest oci:./test/ubuntu:latest
+	[ -f ./test/centos/index.json ] || ./stacker internal-go copy docker://centos:latest oci:./test/centos:latest
+	[ -f ./test/ubuntu/index.json ] || ./stacker internal-go copy docker://ubuntu:latest oci:./test/ubuntu:latest
 	sudo -E "PATH=$$PATH" STORAGE_TYPE=$(subst check-,,$@) $(BATS) --jobs "$(JOBS)" -t $(patsubst %,test/%.bats,$(TEST))
 
 # make check TEST=basic will run only the basic test.

--- a/cmd/internal_go.go
+++ b/cmd/internal_go.go
@@ -115,10 +115,6 @@ var internalGoCmd = cli.Command{
 			Action: doCheckOverlay,
 		},
 		cli.Command{
-			Name:   "testsuite-check-overlay",
-			Action: doTestsuiteCheckOverlay,
-		},
-		cli.Command{
 			Name:   "unpack-tar",
 			Action: doUnpackTar,
 			Flags: []cli.Flag{
@@ -146,6 +142,18 @@ var internalGoCmd = cli.Command{
 					Name: "layer-type",
 				},
 			},
+		},
+		/*
+		 * these two below are not actually used by stacker, but are
+		 * entrypoints to the code for use in the test suite.
+		 */
+		cli.Command{
+			Name:   "testsuite-check-overlay",
+			Action: doTestsuiteCheckOverlay,
+		},
+		cli.Command{
+			Name:   "copy",
+			Action: doImageCopy,
 		},
 	},
 	Before: doBeforeUmociSubcommand,
@@ -548,4 +556,16 @@ func doOverlayConvertAndOutput(ctx *cli.Context) error {
 	layerType := types.LayerType(ctx.String("layer-type"))
 
 	return overlay.ConvertAndOutput(config, tag, name, layerType)
+}
+
+func doImageCopy(ctx *cli.Context) error {
+	if len(ctx.Args()) != 2 {
+		return errors.Errorf("wrong number of args")
+	}
+
+	return lib.ImageCopy(lib.ImageCopyOpts{
+		Src:      ctx.Args()[0],
+		Dest:     ctx.Args()[1],
+		Progress: os.Stdout,
+	})
 }

--- a/doc/install.md
+++ b/doc/install.md
@@ -37,7 +37,6 @@ To run `make check` you will also need:
 
     sudo add-apt-repository ppa:projectatomic/ppa
     sudo apt update
-    sudo apt install skopeo
     sudo apt install bats jq
 
 #### Fedora 31
@@ -47,7 +46,7 @@ packages:
 
     sudo dnf install lxc-devel libcap-devel libacl-devel gpgme-devel
     sudo dnf install btrfs-progs
-    sudo dnf install skopeo bats jq
+    sudo dnf install bats jq
 
 ### Building the Stacker Binary
 

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -60,7 +60,7 @@ EOF
     touch executable
     chmod +x executable
     mkdir -p .stacker/layer-bases
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
     rm -rf dest

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -34,9 +34,9 @@ test:
         type: oci
         url: oci:base
 EOF
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:oci:base
+    image_copy oci:$CENTOS_OCI oci:oci:base
     stacker build
-    skopeo --insecure-policy copy oci:$UBUNTU_OCI oci:oci:base
+    image_copy oci:$UBUNTU_OCI oci:oci:base
     stacker build
     umoci unpack --image oci:test dest
     grep -q Ubuntu dest/rootfs/etc/issue

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -60,6 +60,12 @@ function strace_stacker {
     [ "$status" -eq 0 ]
 }
 
+function image_copy {
+    run "${ROOT_DIR}/stacker" internal-go copy "$@"
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
 function stacker_chroot {
     chroot_run=$(mktemp -p ${TEST_TMPDIR} chroot_runfile.XXXXXXX)
     chroot_stderr=$(mktemp -p ${TEST_TMPDIR} chroot_stderr.XXXXXXX)

--- a/test/intermediate-base-snapshots.bats
+++ b/test/intermediate-base-snapshots.bats
@@ -14,8 +14,8 @@ function teardown() {
     # get a linux to do stuff on
     # (double copy so we can take advantage of caching)
     mkdir -p .stacker/layer-bases
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
-    skopeo --insecure-policy copy oci:.stacker/layer-bases/oci:centos oci:test-oci:a-linux
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    image_copy oci:.stacker/layer-bases/oci:centos oci:test-oci:a-linux
 
     cat > stacker.yaml <<EOF
 # do some stuff
@@ -131,7 +131,7 @@ EOF
 
 @test "intermediate base layers are used" {
     require_storage btrfs
-    skopeo --insecure-policy copy oci:$UBUNTU_OCI oci:oci-import:ubuntu
+    image_copy oci:$UBUNTU_OCI oci:oci-import:ubuntu
     test_intermediate_layers_used tar oci-import:ubuntu
 }
 

--- a/test/oci-import.bats
+++ b/test/oci-import.bats
@@ -20,7 +20,7 @@ output2:
         url: oci:centos
 EOF
 
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:oci:centos
+    image_copy oci:$CENTOS_OCI oci:oci:centos
     stacker build
 
     name0=$(cat oci/index.json | jq -r .manifests[0].annotations.'"org.opencontainers.image.ref.name"')
@@ -38,7 +38,7 @@ centos2:
         type: oci
         url: dest:centos
 EOF
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:dest:centos
+    image_copy oci:$CENTOS_OCI oci:dest:centos
     stacker build
     [ "$(umoci ls --layout ./oci)" == "$(printf "centos2")" ]
 }
@@ -52,7 +52,7 @@ centos3:
     run:
         touch /zomg
 EOF
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:dest:centos:0.1.1
+    image_copy oci:$CENTOS_OCI oci:dest:centos:0.1.1
     stacker build
     [ "$(umoci ls --layout ./oci)" == "$(printf "centos3")" ]
     umoci unpack --image oci:centos3 dest

--- a/test/squashfs.bats
+++ b/test/squashfs.bats
@@ -181,7 +181,7 @@ EOF
 
 @test "built type with squashfs works" {
     mkdir -p .stacker/layer-bases
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
     rm -rf dest
@@ -218,7 +218,7 @@ EOF
 @test "built type with squashfs build-only base works (btrfs)" {
     require_storage btrfs
     mkdir -p .stacker/layer-bases
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
     rm -rf dest
@@ -255,7 +255,7 @@ EOF
 @test "built type with squashfs build-only base works (overlay)" {
     require_storage overlay
     mkdir -p .stacker/layer-bases
-    skopeo --insecure-policy copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
+    image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
     rm -rf dest


### PR DESCRIPTION
This is the nth time the skopeo package install has broken our CI:

    Unpacking containers-common (100:1-7) over (1.2.1~2) ...
    dpkg: error processing archive /tmp/apt-dpkg-install-at4ZRl/03-containers-common_100%3a1-7_all.deb (--unpack):
     trying to overwrite '/usr/share/man/man5/containers-auth.json.5.gz', which is also in package containers-image 5.8.1~1

it looks like the OpenSUSE build infra for Ubuntu maybe just has a bug. But
it's probably pretty brittle anyway, since OpenSUSE doesn't care about
Ubuntu :). While the skopeo binary is available from the Ubuntu universe
repo starting in 20.10, github actions has no plans to support anything
besides Ubuntu LTS releases, so that doesn't help us for another 18 months.

Instead, let's switch to our own copy command. It's not that much code, and
will prevent this from breaking in the future.

Additionally, we can stop passing --insecure-policy everywhere, which is
handy.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>