### PR TITLE
cache: bump cache version + add a test

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vbatts/go-mtree"
 )
 
-const currentCacheVersion = 8
+const currentCacheVersion = 9
 
 type ImportType int
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/anuvu/stacker/types"
+	"github.com/mitchellh/hashstructure"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
 	"github.com/opencontainers/umoci/oci/casext"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLayerHashing(t *testing.T) {
@@ -96,4 +98,21 @@ foo:
 	if ok {
 		t.Errorf("found cached entry when I shouldn't have?")
 	}
+}
+
+func TestCacheEntryChanged(t *testing.T) {
+	assert := assert.New(t)
+
+	h, err := hashstructure.Hash(CacheEntry{}, nil)
+	assert.NoError(err)
+
+	// The goal here is to make sure that the types of things in CacheEntry
+	// haven't changed; if they have (aka this test fails), you should do
+	// currentCacheVersion++, since stackers with an old cache will be
+	// invalid with your current patch.
+	//
+	// This test works because the type information is included in the
+	// hashstructure hash above, so using a zero valued CacheEntry is
+	// enough to capture changes in types.
+	assert.Equal(uint64(0x5acbeb0345d4eeaa), h)
 }

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -182,3 +182,25 @@ EOF
     umoci unpack --image oci:mode-test dest
     [ -x dest/rootfs/executable ]
 }
+
+@test "can read previous version's cache" {
+    git clone https://github.com/anuvu/stacker
+    (cd stacker && make)
+
+    # some additional testing that the cache can be read by older versions of
+    # stacker (cache_test.go has the full test for the type, this just checks
+    # the mechanics of filepaths and such)
+    touch foo
+    cat > stacker.yaml <<EOF
+test:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - foo
+    run: cp /stacker/foo /foo
+EOF
+
+    ./stacker/stacker --storage-type=$STORAGE_TYPE build
+    stacker build
+}

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -204,3 +204,15 @@ EOF
     ./stacker/stacker --storage-type=$STORAGE_TYPE build
     stacker build
 }
+
+@test "different old cache version is ok" {
+    cat > stacker.yaml <<EOF
+test:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+EOF
+    stacker build
+    echo '{"version": 1, "cache": "lolnope"}' > .stacker/build.cache
+    stacker build
+}


### PR DESCRIPTION
If we run this new test with:

diff --git a/test/caching.bats b/test/caching.bats
index b2091d2..bbb0b20 100644
--- a/test/caching.bats
+++ b/test/caching.bats
@@ -185,7 +185,7 @@ EOF

 @test "can read previous version's cache" {
     git clone https://github.com/anuvu/stacker
-    (cd stacker && make)
+    (cd stacker && git co 481c315c8ca3c930fb8a215df8baf0b06bc38bc7 && make)

     # note that this is not quite a complete test: since the cache has a
     # types.Layer in it, anything that can change in there could break this. so

we get:

error: json: cannot unmarshal string into Go struct field Layer.cache.Layer.Import of type types.Import

This is because the commit after 481c315, 60cb730340ac ("Support
specifying hash of import source, closes #119") changed the cache
structure. We have a provision when the cache structure is changed: bump
the cache version so that things are completely invalidated and totally
rebuilt. However, this change snuck through without getting a cache version
bump. So, let's bump it now.

Let's also add a test so hopefully we can catch such things in the future. (As
noted in the test, it's not quite complete, but having some coverage is better
than none.)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>