### PR TITLE
lib/image: set RemoveSignatures

### DIFF
--- a/lib/image.go
+++ b/lib/image.go
@@ -83,7 +83,8 @@ func ImageCopy(opts ImageCopyOpts) error {
 	}
 
 	args := &copy.Options{
-		ReportWriter: opts.Progress,
+		ReportWriter:     opts.Progress,
+		RemoveSignatures: true,
 	}
 
 	args.SourceCtx = &types.SystemContext{}


### PR DESCRIPTION
In spite of us setting our signature policy to
signature.NewPRInsecureAcceptAnything(), containers/image.copy() *still*
wants to read signatures (yes, even if there are none) from somewhere out
of /var/lib/containers. We need to set this new flag to prevent it from
trying to do so.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>