### PR TITLE
tests: add a test for unprivileged docker hub importing

### DIFF
--- a/test/docker-base.bats
+++ b/test/docker-base.bats
@@ -30,3 +30,14 @@ EOF
     umoci unpack --image oci:layer1 dest
     [ ! -f dest/rootfs/favicon.ico ]
 }
+
+@test "unprivileged importing from docker hub" {
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: docker
+        url: docker://centos:latest
+EOF
+    unpriv_setup
+    unpriv_stacker build
+}


### PR DESCRIPTION
The recent containers/image update generated a nasty stack trace in
unprivileged mode:

error: open /var/lib/containers/sigstore/library/centos@sha256=dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875/signature-1: permission denied
Error reading signatures
github.com/containers/image/v5/copy.(*copier).copyOneImage
	/home/tycho/packages/go/pkg/mod/github.com/anuvu/image/v5@v5.0.0-20210310195111-044dd755e25e/copy/copy.go:652
github.com/containers/image/v5/copy.Image
	/home/tycho/packages/go/pkg/mod/github.com/anuvu/image/v5@v5.0.0-20210310195111-044dd755e25e/copy/copy.go:330
github.com/anuvu/stacker/lib.ImageCopy
	/home/tycho/packages/stacker/lib/image.go:115
github.com/anuvu/stacker.importContainersImage

which is fixed in the previous patch. We didn't catch this because we don't run
the docker import test as an unprivileged user, and the containers/image code
ignores ENOENT but not EACCES.

We should probably do some work to enhance the test matrix and add a new priv
vs. unpriv axis, especially since we now run a lot more code inside a userns
after fbf785082212 ("exe: run all commands in a userns"). But for now, let's
just add another test so we cover this case.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>