### PR TITLE
tests: add an unprivileged axis to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,8 @@ jobs:
                   go-version: ${{ matrix.go-version }}
             - name: install dependencies
               run: |
-                  source /etc/os-release
+                  sudo ls /etc/apt/sources.list.d/*
+                  sudo rm -rf /etc/apt/sources.list.d/*
                   sudo add-apt-repository -y ppa:ubuntu-lxc/lxc-git-master
                   sudo apt-get update
                   sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev bats parallel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,12 @@ on:
 jobs:
     build:
         runs-on: ubuntu-20.04
-        name: "golang ${{ matrix.go-version }} storage-type ${{ matrix.storage-backend }}"
+        name: "golang ${{ matrix.go-version }} storage-type ${{ matrix.storage-type }} privilege ${{ matrix.privilege-level }}"
         strategy:
             matrix:
                 go-version: [1.15.x, 1.16.x]
-                storage-backend: [btrfs, overlay]
+                storage-type: [btrfs, overlay]
+                privilege-level: [priv, unpriv]
         steps:
             - uses: actions/checkout@v2
             - name: Set up golang ${{ matrix.go-version }}
@@ -32,4 +33,5 @@ jobs:
                   sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools
                   (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
                   (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)
-            - run: make lint check-${{ matrix.storage-backend }}
+            - run: |
+                  make check STORAGE_TYPE=${{ matrix.storage-type }} PRIVILEGE_LEVEL=${{ matrix.privilege-level }}

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Additionally, there are some [tips and tricks](doc/tricks.md) for common usage.
 * Upstream something to containers/image that allows for automatic detection
   of compression
 * Design/implement OCIv2 drafts + final spec when it comes out
-* Rearrange tests so there's more unprivileged coverage (really should be
-  another row/column in the test matrix like storage type is)
 
 ### Conference Talks
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -33,10 +33,6 @@ func doClean(ctx *cli.Context) error {
 		err = s.Clean()
 		if err != nil {
 			log.Infof("problem cleaning roots %v", err)
-		}
-		err = os.RemoveAll(config.RootFSDir)
-		if err != nil {
-			log.Infof("problem cleaning roots %v", err)
 			fail = true
 		}
 	}

--- a/storage.go
+++ b/storage.go
@@ -29,6 +29,7 @@ func openStorage(c types.StackerConfig, storageType string) (types.Storage, erro
 	case "btrfs":
 		isBtrfs, err := btrfs.DetectBtrfs(c.RootFSDir)
 		if err != nil {
+			log.Infof("error from DetectBtrfs %v", err)
 			return nil, err
 		}
 
@@ -74,8 +75,8 @@ func tryToDetectStorageType(c types.StackerConfig) (string, error) {
 	}
 
 	for _, ent := range ents {
-		log.Debugf("detected some overlay layers, assuming previous storage type overlay")
 		if _, err := os.Stat(path.Join(c.RootFSDir, ent.Name(), "overlay")); err == nil {
+			log.Debugf("detected some overlay layers, assuming previous storage type overlay")
 			return "overlay", nil
 		}
 	}
@@ -122,6 +123,7 @@ func maybeSwitchStorage(c types.StackerConfig) error {
 	if err != nil {
 		return err
 	}
+	log.Infof("after clean")
 
 	err = os.Remove(c.CacheFile())
 	// it's ok if it didn't exist, this is probably a new run of stacker

--- a/test/build-only.bats
+++ b/test/build-only.bats
@@ -129,7 +129,6 @@ EOF
 
 @test "build only + unpriv + overlay clears state" {
     require_storage overlay
-    unpriv_setup
     cat > stacker.yaml <<"EOF"
 first:
     from:
@@ -146,6 +145,6 @@ first:
         chmod 500 $THEPATH
 EOF
 
-    unpriv_stacker build --layer-type=squashfs --substitute "RUN_NUMBER=1" --substitute CENTOS_OCI=$CENTOS_OCI
-    unpriv_stacker build --layer-type=squashfs --substitute "RUN_NUMBER=2" --substitute CENTOS_OCI=$CENTOS_OCI
+    stacker build --layer-type=squashfs --substitute "RUN_NUMBER=1" --substitute CENTOS_OCI=$CENTOS_OCI
+    stacker build --layer-type=squashfs --substitute "RUN_NUMBER=2" --substitute CENTOS_OCI=$CENTOS_OCI
 }

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -201,7 +201,13 @@ test:
     run: cp /stacker/foo /foo
 EOF
 
-    ./stacker/stacker --storage-type=$STORAGE_TYPE build
+    if [ "$PRIVILEGE_LEVEL" = "priv" ]; then
+        ./stacker/stacker --storage-type=$STORAGE_TYPE --debug build
+    else
+        skip_if_no_unpriv_overlay
+        sudo -u $SUDO_USER ./stacker/stacker --storage-type=$STORAGE_TYPE --debug build
+    fi
+
     stacker build
 }
 

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -17,7 +17,7 @@ function teardown() {
     mount -o loop,user_subvol_rm_allowed btrfs.loop parent
     mkdir -p parent/roots
 
-    stacker --roots-dir=parent/roots clean
+    stacker --stacker-dir .otherstacker --roots-dir=parent/roots clean
 }
 
 @test "clean in the face of subvolumes works" {
@@ -25,23 +25,25 @@ function teardown() {
 
     truncate -s 10G btrfs.loop
     mkfs.btrfs btrfs.loop
-    mkdir -p parent
+    run_as mkdir -p parent
     mount -o loop,user_subvol_rm_allowed btrfs.loop parent
-    mkdir -p parent/roots
+    chmod 777 parent
+    run_as mkdir -p parent/roots
 
     # create some subvolumes and make them all readonly
-    btrfs subvol create parent/roots/a
-    btrfs property set -ts parent/roots/a ro true
-    btrfs subvol create parent/roots/b
-    btrfs property set -ts parent/roots/b ro true
-    btrfs subvol create parent/roots/c
-    btrfs property set -ts parent/roots/c ro true
+    run_as btrfs subvol create parent/roots/a
+    run_as btrfs property set -ts parent/roots/a ro true
+    run_as btrfs subvol create parent/roots/b
+    run_as btrfs property set -ts parent/roots/b ro true
+    run_as btrfs subvol create parent/roots/c
+    run_as btrfs property set -ts parent/roots/c ro true
 
     # stacker clean with a roots dir that is already on btrfs should succeed
-    stacker --roots-dir=parent/roots clean
+    stacker --stacker-dir .otherstacker --roots-dir=parent/roots clean
 
     [ -d parent ]
-    [ ! -d parent/roots ]
+    tree parent
+    [ "$PRIVILEGE_LEVEL" == "unpriv" ] || [ ! -d parent/roots ]
 }
 
 @test "unpriv subvol clean works" {
@@ -51,7 +53,8 @@ function teardown() {
     mkfs.btrfs btrfs.loop
     mkdir -p parent
     mount -o loop,user_subvol_rm_allowed btrfs.loop parent
-    mkdir -p parent/roots
+    chmod 777 parent
+    run_as mkdir -p parent/roots
 
     # create some subvolumes and make them all readonly
     btrfs subvol create parent/roots/a
@@ -60,7 +63,7 @@ function teardown() {
     btrfs property set -ts parent/roots/a/b ro true
     btrfs property set -ts parent/roots/a ro true
 
-    unpriv_stacker --roots-dir=parent/roots clean
+    stacker --stacker-dir .otherstacker --roots-dir=parent/roots clean
     [ ! -d parent/roots/a ]
     [ ! -d parent/roots/a/b ]
 }
@@ -70,21 +73,23 @@ function teardown() {
 
     truncate -s 10G btrfs.loop
     mkfs.btrfs btrfs.loop
-    mkdir -p parent
+    run_as mkdir -p parent
     mount -o loop,user_subvol_rm_allowed btrfs.loop parent
-    mkdir -p parent/roots
+    chmod 777 parent
+    run_as mkdir -p parent/roots
 
-    btrfs subvol create parent/roots/a
+    run_as btrfs subvol create parent/roots/a
     # we had a bad bug one time where we forgot to join the root path with the
     # subvolume we were deleting, so these got deleted.
     mkdir a
-    stacker --roots-dir=parent/roots clean
+    stacker --stacker-dir .otherstacker --roots-dir=parent/roots clean
     [ ! -d parent/roots/a ]
     [ -d a ]
 }
 
 @test "clean in loopback mode works" {
     require_storage btrfs
+    require_privilege priv
 
     cat > stacker.yaml <<EOF
 test:
@@ -100,7 +105,6 @@ EOF
 
 @test "clean of unpriv overlay works" {
     require_storage overlay
-    unpriv_setup
 
     cat > stacker.yaml <<EOF
 test:
@@ -108,6 +112,6 @@ test:
         type: oci
         url: $CENTOS_OCI
 EOF
-    unpriv_stacker build
-    unpriv_stacker clean
+    stacker build
+    stacker clean
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -10,6 +10,8 @@ function teardown() {
 }
 
 @test "config args work" {
+    require_privilege priv
+
     local tmpd=$(pwd)
     echo "tmpd $tmpd"
     cat > stacker.yaml <<EOF
@@ -26,6 +28,8 @@ EOF
 }
 
 @test "config file works" {
+    require_privilege priv
+
     local tmpd=$(pwd)
     echo "tmpd $tmpd"
     find $tmpd
@@ -48,6 +52,8 @@ EOF
 }
 
 @test "config file substitutions work" {
+    require_privilege priv
+
     # the stacker file provided runs a 'my-build' that creates /my-publish/output.tar
     # output.tar's content.txt file should have the rendered values
     # for STACKER_ROOTFS_DIR STACKER_OCI_DIR and STACKER_STACKER_DIR

--- a/test/container-setup.bats
+++ b/test/container-setup.bats
@@ -11,6 +11,7 @@ function teardown() {
 
 @test "container-setup: two containers works" {
     require_storage btrfs
+    require_privilege priv
     cat > stacker.yaml <<EOF
 a:
     from:
@@ -45,6 +46,7 @@ EOF
 
 @test "container-setup generates a config" {
     require_storage btrfs
+    require_privilege priv
     cat > stacker.yaml <<EOF
 test:
     from:

--- a/test/docker-base.bats
+++ b/test/docker-base.bats
@@ -26,18 +26,8 @@ layer1:
         - rm /favicon.ico
 EOF
     stacker build
-    [ "$(sha .stacker/imports/centos/favicon.ico)" == "$(stacker_chroot sha /favicon.ico)" ]
+    stacker grab centos:/favicon.ico
+    [ "$(sha .stacker/imports/centos/favicon.ico)" == "$(sha favicon.ico)" ]
     umoci unpack --image oci:layer1 dest
     [ ! -f dest/rootfs/favicon.ico ]
-}
-
-@test "unprivileged importing from docker hub" {
-    cat > stacker.yaml <<EOF
-centos:
-    from:
-        type: docker
-        url: docker://centos:latest
-EOF
-    unpriv_setup
-    unpriv_stacker build
 }

--- a/test/env.bats
+++ b/test/env.bats
@@ -11,6 +11,7 @@ function teardown() {
 @test "/stacker is ro" {
     mkdir -p .stacker/imports/test
     touch .stacker/imports/test/foo
+    chmod -R 777 .stacker/imports
 
     cat > stacker.yaml <<EOF
 test:

--- a/test/import-http.bats
+++ b/test/import-http.bats
@@ -39,6 +39,8 @@ function teardown() {
 }
 
 @test "importing from cache works for unreachable http urls" {
+    require_privilege priv
+
     # Build base image
     stacker build -f img/stacker1.yaml
     umoci ls --layout oci

--- a/test/main.py
+++ b/test/main.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+
+import argparse
+import glob
+import multiprocessing
+import os
+import subprocess
+import sys
+
+storage_types=("btrfs", "overlay")
+priv_levels=("priv", "unpriv")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--storage-type", choices=storage_types)
+parser.add_argument("--privilege-level", choices=priv_levels)
+parser.add_argument("--jobs", type=int, default=multiprocessing.cpu_count())
+parser.add_argument("tests", nargs="*", default=glob.glob("./test/*.bats"))
+
+options = parser.parse_args()
+
+storage_to_test=storage_types
+priv_to_test=priv_levels
+
+if options.storage_type is not None:
+    storage_to_test = [options.storage_type]
+if options.privilege_level is not None:
+    priv_to_test = [options.privilege_level]
+
+for st in storage_to_test:
+    for priv in priv_to_test:
+        cmd = ["bats", "--jobs", str(options.jobs), "-t"]
+        cmd.extend(options.tests)
+
+        env = os.environ.copy()
+        env["STORAGE_TYPE"] = st
+        env["PRIVILEGE_LEVEL"] = priv
+
+        print("running tests in modes:", st, priv)
+        try:
+            subprocess.check_call(cmd, env=env)
+        except subprocess.CalledProcessError:
+            print("tests in modes:", st, priv, "failed")
+            sys.exit(1)

--- a/test/prerequisites.bats
+++ b/test/prerequisites.bats
@@ -55,6 +55,7 @@ layer3_2:
     run: |
         cp /root/import0 /root/import0_copied
 EOF
+    chown -R $SUDO_USER:$SUDO_USER .
 }
 
 function teardown() {
@@ -71,9 +72,9 @@ function teardown() {
 }
 
 @test "search for multiple stackerfiles using default settings" {
-    cd ocibuilds
     # Search for all stackerfiles under current directory and produce a build order
     stacker recursive-build --order-only
+    echo $output
     [[ "${lines[-1]}" =~ ^(2 build .*ocibuilds\/sub3\/stacker\.yaml: requires: \[.*\/sub1\/stacker\.yaml .*\/sub2\/stacker\.yaml\])$ ]]
     [[ "${lines[-2]}" =~ ^(1 build .*ocibuilds\/sub2\/stacker\.yaml: requires: \[.*\/sub1\/stacker\.yaml\])$ ]]
     [[ "${lines[-3]}" =~ ^(0 build .*ocibuilds\/sub1\/stacker\.yaml: requires: \[\])$ ]]

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -3,7 +3,6 @@ load helpers
 function setup() {
     stacker_setup
     mkdir -p ocibuilds/sub1
-    mkdir oci_publish
     touch ocibuilds/sub1/import1
     cat > ocibuilds/sub1/stacker.yaml <<EOF
 layer1:

--- a/test/squashfs.bats
+++ b/test/squashfs.bats
@@ -181,6 +181,7 @@ EOF
 
 @test "built type with squashfs works" {
     mkdir -p .stacker/layer-bases
+    chmod 777 .stacker/layer-bases
     image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
@@ -218,6 +219,7 @@ EOF
 @test "built type with squashfs build-only base works (btrfs)" {
     require_storage btrfs
     mkdir -p .stacker/layer-bases
+    chmod 777 .stacker/layer-bases
     image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .
@@ -255,6 +257,7 @@ EOF
 @test "built type with squashfs build-only base works (overlay)" {
     require_storage overlay
     mkdir -p .stacker/layer-bases
+    chmod 777 .stacker/layer-bases
     image_copy oci:$CENTOS_OCI oci:.stacker/layer-bases/oci:centos
     umoci unpack --image .stacker/layer-bases/oci:centos dest
     tar caf .stacker/layer-bases/centos.tar -C dest/rootfs .

--- a/test/storage.bats
+++ b/test/storage.bats
@@ -10,6 +10,7 @@ function teardown() {
 
 @test "btrfs -> overlay -> btrfs works" {
     require_storage btrfs # only run this once
+    require_privilege priv
 
     cat > stacker.yaml <<EOF
 test:
@@ -32,6 +33,7 @@ EOF
 
 @test "overlay -> btrfs -> overlay works" {
     require_storage btrfs # only run this once
+    require_privilege priv
 
     cat > stacker.yaml <<EOF
 test:


### PR DESCRIPTION
Rather than have some tests that we run unprivileged, and some that we run
privileged, let's run everything in both configurations so we can increase
coverage.

There are a bunch of changes to the testsuite needed; this is because the
testsuite runs as root, but we want to run stacker as non-root. So e.g.
when we do mkdirs or whatever for things stacker needs to be able to
read/write, we need to chown those in non-root mode.

This commit introduces the run_as helper, which runs things as the right
user in the test suite. Probably some more of the test suite modifications
could be ported to use this helper.

This commit also changes the way Clean() works slightly: the common clean
code no longer deletes (and thus no longer fails on deleting) the roots
directory. This is because in unpriv+btrfs mode, one cannot necessarily
unmount the roots dir if someone has done unpriv-setup. So we just exit(1)
with a warning in this case. The overlay code already deleted this dir, so
the extra delete code was redundant.

Finally, this commit also adds a few missing errors.Wrapf()s to errors
coming from the filesystem.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>