### PR TITLE
unpriv-setup: don't run inside a userns

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -244,7 +244,7 @@ func main() {
 		stackerlog.FilterNonStackerLogs(handler, logLevel)
 		stackerlog.Debugf("stacker version %s", version)
 
-		if !ctx.Bool("internal-userns") {
+		if !ctx.Bool("internal-userns") && len(ctx.Args()) >= 1 && ctx.Args()[0] != "unpriv-stacker" {
 			binary, err := os.Readlink("/proc/self/exe")
 			if err != nil {
 				return err


### PR DESCRIPTION
If we run this in a userns, we won't have permissions to edit e.g.
/etc/subuid and /etc/subgid on the host.

This is a bit of a hack, but ctx.Args() in the app's Before() method has
argv[0] == $subcommand, so we 1. test that there is a subcommand and 2.
test that it is not unpriv-setup before we re-exec.

Closes #146

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>