### PR TITLE
Revert "try to fix CI"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
                   go-version: ${{ matrix.go-version }}
             - name: install dependencies
               run: |
-                  sudo ls /etc/apt/sources.list.d/*
-                  sudo rm -rf /etc/apt/sources.list.d/*
                   sudo add-apt-repository -y ppa:ubuntu-lxc/lxc-git-master
                   sudo apt-get update
                   sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev bats parallel


### PR DESCRIPTION
This reverts commit 9f228230bc05090cea14df7e8182f79b4d43253c.

We don't need this cache clearing any more, so let's drop it.