### PR TITLE
Copy imports into layer's rootfs

### DIFF
--- a/build.go
+++ b/build.go
@@ -405,6 +405,13 @@ func (b *Builder) Build(s types.Storage, file string) error {
 			return err
 		}
 
+		// code for copy imports in rootfs
+		log.Debugf("Copying imports into %s's rootfs", name)
+		err = copyImportsInRootfs(name, imports, opts.Config, s)
+		if err != nil {
+			return err
+		}
+
 		c, err := NewContainer(opts.Config, s, name)
 		if err != nil {
 			return err

--- a/lib/dir.go
+++ b/lib/dir.go
@@ -1,0 +1,67 @@
+package lib
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+// DirCopy copies a whole directory recursively
+func DirCopy(dest string, source string) error {
+
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = os.Stat(source); err != nil {
+		return err
+	}
+
+	linkFI, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+
+	// in case the dir is a symlink
+	if linkFI.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(source)
+		if err != nil {
+			return err
+		}
+
+		return os.Symlink(target, dest)
+	}
+
+	//var dirMode os.FileMode
+	//if preservePermissions {
+	//	dirMode = srcinfo.Mode()
+	//} else {
+	//	dirMode = 0755
+	//}
+
+	dirMode := srcinfo.Mode()
+
+	if err = os.MkdirAll(dest, dirMode); err != nil {
+		return err
+	}
+
+	if fds, err = ioutil.ReadDir(source); err != nil {
+		return err
+	}
+
+	for _, fd := range fds {
+		srcfp := path.Join(source, fd.Name())
+		dstfp := path.Join(dest, fd.Name())
+
+		if fd.IsDir() {
+			if err = DirCopy(dstfp, srcfp); err != nil {
+				return err
+			}
+		} else {
+			if err = FileCopy(dstfp, srcfp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/lib/file.go
+++ b/lib/file.go
@@ -31,17 +31,34 @@ func FileCopy(dest string, source string) error {
 	}
 	defer s.Close()
 
-	fi, err := s.Stat()
-	if err != nil {
-		return err
-	}
-
 	d, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
 	defer d.Close()
 
+	fi, err := s.Stat()
+	if err != nil {
+		return err
+	}
+
+	//if preservePermissions {
+	//	err = d.Chmod(fi.Mode())
+	//	if err != nil {
+	//		return err
+	//	}
+	//} else {
+	//	// preserve executable
+	//	if IsExecOwner(fi.Mode()) {
+	//		err = d.Chmod(0700)
+	//		if err != nil {
+	//			return err
+	//		}
+	//	}
+	//	// preserve time
+	//	if err = os.Chtimes(dest, fi.ModTime(), fi.ModTime()); err != nil {
+	//		return err
+	//	}
 	err = d.Chmod(fi.Mode())
 	if err != nil {
 		return err
@@ -80,4 +97,8 @@ func FindFiles(base, pattern string) ([]string, error) {
 	err = filepath.Walk(base, visit)
 
 	return paths, err
+}
+
+func IsExecOwner(mode os.FileMode) bool {
+	return mode&0100 != 0
 }


### PR DESCRIPTION
Copy them into the specified destination
otherwise copy them into layer's rootfs "/"
Preserves links, executability, times.
Don't preserve user/grop ownership and perms.
closes #83