### PR TITLE
build: always annotate with the input stacker.yaml

### DIFF
--- a/build.go
+++ b/build.go
@@ -235,9 +235,9 @@ func (b *Builder) updateOCIConfigForOutput(sf *types.Stackerfile, s types.Storag
 	if gitVersion != "" {
 		log.Debugf("setting git version annotation to %s", gitVersion)
 		annotations[GitVersionAnnotation] = gitVersion
-	} else {
-		annotations[StackerContentsAnnotation] = sf.AfterSubstitutions
 	}
+
+	annotations[StackerContentsAnnotation] = sf.AfterSubstitutions
 
 	history := ispec.History{
 		EmptyLayer: true, // this is only the history for imageConfig edit

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -99,6 +99,14 @@ EOF
         dirty="-dirty" || dirty=""
     [ "$publishedGitVersion" = "$myGitVersion$dirty" ]
 
+    # need to trim the extra newline from jq
+    cat oci/blobs/sha256/$manifest | jq -r '.annotations."com.cisco.stacker.stacker_yaml"' | sed '$ d' > stacker_yaml_annotation
+
+    # now we need to do --substitute FAVICON=favicon.ico
+    sed -e 's/$FAVICON/favicon.ico/g' stacker.yaml > stacker_after_subs
+
+    diff -U5 stacker_yaml_annotation stacker_after_subs
+
     [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Env[0]')" = "FOO=bar" ]
     [ "$(cat oci/blobs/sha256/$config | jq -r '.config.User')" = "1000" ]
     [ "$(cat oci/blobs/sha256/$config | jq -r '.config.Volumes["/data/db"]')" = "{}" ]


### PR DESCRIPTION
I have no idea why we did if/else here, but it seems fairly reasonable to
want both the stacker.yaml and the git hash (even if the git hash could
tell you the stacker yaml, it won't necessarily tell you the value of
--substitutions or whatever that people ran with). Let's include both.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>