### PR TITLE
Add an overlay_dirs yaml entry

### DIFF
--- a/btrfs/btrfs.go
+++ b/btrfs/btrfs.go
@@ -508,3 +508,10 @@ func setupLoopback(path string, uid int, gid int, size int64) error {
 
 	return nil
 }
+
+func (b *btrfs) SetOverlayDirs(name string, overlayDirs types.OverlayDirs, layerTypes []types.LayerType) error {
+	if len(overlayDirs) == 0 {
+		return nil
+	}
+	return errors.Errorf("Using overlay_dirs with btrfs storage is forbidden, use overlay storage instead")
+}

--- a/build.go
+++ b/build.go
@@ -407,6 +407,16 @@ func (b *Builder) Build(s types.Storage, file string) error {
 			return err
 		}
 
+		overlayDirs, err := l.ParseOverlayDirs()
+		if err != nil {
+			return err
+		}
+
+		err = s.SetOverlayDirs(name, overlayDirs, opts.LayerTypes)
+		if err != nil {
+			return err
+		}
+
 		c, err := NewContainer(opts.Config, s, name)
 		if err != nil {
 			return err

--- a/cache_test.go
+++ b/cache_test.go
@@ -114,5 +114,5 @@ func TestCacheEntryChanged(t *testing.T) {
 	// This test works because the type information is included in the
 	// hashstructure hash above, so using a zero valued CacheEntry is
 	// enough to capture changes in types.
-	assert.Equal(uint64(0x5acbeb0345d4eeaa), h)
+	assert.Equal(uint64(0x22f75070ead4ce2e), h)
 }

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -106,7 +106,22 @@ import:
   - /path/to/file
 ```
 
+### `overlay_dirs`
+This directive works only with OverlayFS backend storage.
 
+The `overlay_dirs` directive describes what directories (content) from the host should be
+available in the container's filesystem. It preserves all file/dirs attributes but no
+owner or group.
+
+```
+overlay_dirs:
+  - source: /path/to/directory
+    dest: /usr/local/          ## optional arg, default is '/'
+  - source: /path/to/directory2
+```
+This example will result in all the files/dirs from the host's /path/to/directory 
+to be available under container's /usr/local/ and all the files/dirs from the host's
+/path/to/directory2 to be available under container's /
 
 
 #### `environment`, `labels`, `working_dir`, `volumes`, `cmd`, `entrypoint`, `user`

--- a/lib/dir.go
+++ b/lib/dir.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+)
+
+// DirCopy copies a whole directory recursively
+func DirCopy(dest string, source string) error {
+
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = os.Stat(source); err != nil {
+		return errors.Wrapf(err, "Coudn't stat %s", source)
+	}
+
+	linkFI, err := os.Lstat(source)
+	if err != nil {
+		return errors.Wrapf(err, "Coudn't stat link %s", source)
+	}
+
+	// in case the dir is a symlink
+	if linkFI.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(source)
+		if err != nil {
+			return errors.Wrapf(err, "Coudn't read link %s", source)
+		}
+
+		return os.Symlink(target, dest)
+	}
+
+	dirMode := srcinfo.Mode()
+
+	if err = os.MkdirAll(dest, dirMode); err != nil {
+		return errors.Wrapf(err, "Coudn't mkdir %s", dest)
+	}
+
+	if fds, err = ioutil.ReadDir(source); err != nil {
+		return errors.Wrapf(err, "Coudn't read dir %s", source)
+	}
+
+	for _, fd := range fds {
+		srcfp := path.Join(source, fd.Name())
+		dstfp := path.Join(dest, fd.Name())
+
+		if fd.IsDir() {
+			if err = DirCopy(dstfp, srcfp); err != nil {
+				return err
+			}
+		} else {
+			if err = FileCopy(dstfp, srcfp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/lib/file.go
+++ b/lib/file.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 func FileCopy(dest string, source string) error {
@@ -12,14 +14,14 @@ func FileCopy(dest string, source string) error {
 
 	linkFI, err := os.Lstat(source)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Coudn't stat link %s", source)
 	}
 
 	// If it's a link, it might be broken. In any case, just copy it.
 	if linkFI.Mode()&os.ModeSymlink != 0 {
 		target, err := os.Readlink(source)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Coudn't read link %s", source)
 		}
 
 		return os.Symlink(target, dest)
@@ -27,24 +29,24 @@ func FileCopy(dest string, source string) error {
 
 	s, err := os.Open(source)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Coudn't open file %s", source)
 	}
 	defer s.Close()
 
 	fi, err := s.Stat()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Coudn't stat file %s", source)
 	}
 
 	d, err := os.Create(dest)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Coudn't create file %s", dest)
 	}
 	defer d.Close()
 
 	err = d.Chmod(fi.Mode())
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Coudn't chmod file %s", source)
 	}
 
 	_, err = io.Copy(d, s)

--- a/overlay/overlay-dirs.go
+++ b/overlay/overlay-dirs.go
@@ -1,0 +1,93 @@
+package overlay
+
+import (
+	"os"
+	"path"
+
+	"github.com/anuvu/stacker/lib"
+	"github.com/anuvu/stacker/types"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/umoci"
+	"github.com/pkg/errors"
+)
+
+// generateOverlayDirsLayers generates oci layers from all overlay_dirs of this image
+// and saves the layer descriptors in the overlay_metadata.json
+func generateOverlayDirsLayers(name string, layerTypes []types.LayerType, overlayDirs types.OverlayDirs, config types.StackerConfig) error {
+	ovl, err := readOverlayMetadata(config, name)
+	if err != nil {
+		return err
+	}
+	ovl.OverlayDirLayers = make(map[types.LayerType][]ispec.Descriptor, 1)
+	for _, layerType := range layerTypes {
+		for _, od := range overlayDirs {
+			desc, err := generateOverlayDirLayer(name, layerType, od, config)
+			if err != nil {
+				return err
+			}
+			ovl.OverlayDirLayers[layerType] = append(ovl.OverlayDirLayers[layerType], desc)
+		}
+	}
+	err = ovl.write(config, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateOverlayDirLayer generates an oci layer from one overlay_dir
+func generateOverlayDirLayer(name string, layerType types.LayerType, overlayDir types.OverlayDir, config types.StackerConfig) (ispec.Descriptor, error) {
+	oci, err := umoci.OpenLayout(config.OCIDir)
+	if err != nil {
+		return ispec.Descriptor{}, err
+	}
+	defer oci.Close()
+
+	contents := path.Join(config.RootFSDir, name, "overlay_dirs", path.Base(overlayDir.Source))
+	blob, err := generateBlob(layerType, contents, config.OCIDir)
+	if err != nil {
+		return ispec.Descriptor{}, err
+	}
+	defer blob.Close()
+
+	desc, err := ociPutBlob(blob, config, layerType)
+	if err != nil {
+		return ispec.Descriptor{}, err
+	}
+
+	if err = os.MkdirAll(overlayPath(config, desc.Digest), 0755); err != nil {
+		return ispec.Descriptor{}, err
+	}
+
+	err = os.Symlink(contents, overlayPath(config, desc.Digest, "overlay"))
+	if err != nil {
+		return ispec.Descriptor{}, errors.Wrapf(err, "failed to create symlink")
+	}
+
+	return desc, nil
+}
+
+// copyOverlayDirs copies each overlay_dir into container 'name' rootfs
+// later they will be outputted as layers by using generateOverlayDirLayer
+func copyOverlayDirs(name string, overlayDirs types.OverlayDirs, rootfs string) error {
+	for _, overlayDir := range overlayDirs {
+		st, err := os.Stat(overlayDir.Source)
+		if os.IsNotExist(err) {
+			return errors.Errorf("Given overlay_dir %s doesn't exists", overlayDir.Source)
+		}
+		if !st.IsDir() {
+			return errors.Errorf("Given overlay_dir %s should be a directory", overlayDir.Source)
+		}
+		contents := path.Join(rootfs, name, "overlay_dirs", path.Base(overlayDir.Source), overlayDir.Dest)
+		if _, err := os.Stat(contents); os.IsNotExist(err) {
+			if err = os.MkdirAll(contents, 0755); err != nil {
+				return err
+			}
+		}
+		if err := lib.DirCopy(contents, overlayDir.Source); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -243,3 +243,22 @@ func (o *overlay) GetLXCRootfsConfig(name string) (string, error) {
 func (o *overlay) TarExtractLocation(name string) string {
 	return path.Join(o.config.RootFSDir, name, "overlay")
 }
+
+// Add overlay_dirs into overlay metadata so that later we can mount them in the lxc container
+func (o *overlay) SetOverlayDirs(name string, overlayDirs types.OverlayDirs, layerTypes []types.LayerType) error {
+	if len(overlayDirs) == 0 {
+		return nil
+	}
+	// copy overlay_dirs contents into a temporary dir in roots
+	err := copyOverlayDirs(name, overlayDirs, o.config.RootFSDir)
+	if err != nil {
+		return err
+	}
+	// generate layers from above overlay_dirs
+	err = generateOverlayDirsLayers(name, layerTypes, overlayDirs, o.config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/overlay-dirs.bats
+++ b/test/overlay-dirs.bats
@@ -1,0 +1,122 @@
+load helpers
+
+function setup() {
+    stacker_setup
+}
+
+function teardown() {
+    cleanup
+    rm -rf recursive bing.ico || true
+}
+
+@test "overlay_dirs works" {
+    require_storage overlay
+    mkdir dir_to_overlay
+    touch dir_to_overlay/file1
+    touch dir_to_overlay/file2
+    touch dir_to_overlay/executable
+    chmod +x dir_to_overlay/executable
+    cat > stacker.yaml << EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    overlay_dirs:
+        - source: dir_to_overlay
+    run: |
+        [ -f /file1 ]
+        [ -f /file2 ]
+        [ -x /executable ]
+EOF
+    stacker build
+}
+
+@test "import from overlay_dir works" {
+    require_storage overlay
+    mkdir dir_to_overlay
+    touch dir_to_overlay/file
+    cat > stacker.yaml << EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    overlay_dirs:
+        - source: dir_to_overlay
+    run: |
+        [ -f /file ]
+second:
+    from:
+        type: built
+        tag: first
+    import: stacker://first/file
+    run: |
+        [ -f /stacker/file ]
+EOF
+    stacker build
+}
+
+@test "overlay_dirs dest works" {
+    require_storage overlay
+    mkdir dir_to_overlay
+    touch dir_to_overlay/file
+    cat > stacker.yaml << EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    overlay_dirs:
+        - source: dir_to_overlay
+          dest: /usr/local
+    run: |
+        [ -f /usr/local/file ]
+EOF
+    stacker build
+}
+
+@test "overlay_dirs cache works" {
+    require_storage overlay
+    mkdir dir_to_overlay
+    touch dir_to_overlay/file
+    cat > stacker.yaml << EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    overlay_dirs:
+        - source: dir_to_overlay
+          dest: /usr/local
+    run: |
+        [ -f /usr/local/file ]
+EOF
+    stacker build
+    stacker build
+    echo $output | grep "found cached layer first"
+    echo "modifying file" > dir_to_overlay/file
+    stacker build
+    echo $output | grep "cache miss because overlay_dir content changed"
+    rm -rf roots
+    stacker build
+    echo $output | grep "cache miss because overlay_dir was missing"
+}
+
+@test "overlay_dirs don't preserve ownership" {
+    require_storage overlay
+    mkdir dir_to_overlay
+    touch dir_to_overlay/file
+    touch dir_to_overlay/file2
+    chown 1234:1234 dir_to_overlay/file
+    cat > stacker.yaml << EOF
+first:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    overlay_dirs:
+        - source: dir_to_overlay
+          dest: /usr/local
+    run: |
+        [ -f /usr/local/file ]
+        [ "\$(stat --format=%G /usr/local/file )" == "root" ]
+        [ "\$(stat --format=%U /usr/local/file )" == "root" ]
+EOF
+    stacker build
+}

--- a/types/layer.go
+++ b/types/layer.go
@@ -35,11 +35,18 @@ type Import struct {
 	Hash string `yaml:"hash"`
 }
 
+type OverlayDir struct {
+	Source string `yaml:"source"`
+	Dest   string `yaml:"dest"`
+}
+
+type OverlayDirs []OverlayDir
 type Imports []Import
 
 type Layer struct {
 	From               *ImageSource      `yaml:"from"`
 	Import             Imports           `yaml:"import"`
+	OverlayDirs        OverlayDirs       `yaml:"overlay_dirs"`
 	Run                interface{}       `yaml:"run"`
 	Cmd                interface{}       `yaml:"cmd"`
 	Entrypoint         interface{}       `yaml:"entrypoint"`
@@ -211,6 +218,20 @@ func (l *Layer) ParseImport() (Imports, error) {
 		absImports = append(absImports, absImport)
 	}
 	return absImports, nil
+}
+
+func (l *Layer) ParseOverlayDirs() (OverlayDirs, error) {
+	var absOverlayDirs OverlayDirs
+	var absOverlayDir OverlayDir
+	for _, rawOverlayDir := range l.OverlayDirs {
+		absOverlayDirSource, err := l.getAbsPath(rawOverlayDir.Source)
+		if err != nil {
+			return nil, err
+		}
+		absOverlayDir = OverlayDir{Source: absOverlayDirSource, Dest: rawOverlayDir.Dest}
+		absOverlayDirs = append(absOverlayDirs, absOverlayDir)
+	}
+	return absOverlayDirs, nil
 }
 
 func (l *Layer) ParseBinds() (map[string]string, error) {

--- a/types/layer.go
+++ b/types/layer.go
@@ -80,10 +80,10 @@ func getImportFromInterface(v interface{}) (Import, error) {
 	m2, ok := v.(map[string]interface{})
 	if ok {
 		// check for nil hash so that we won't end up with "nil" string values
-		if m["hash"] == nil {
+		if m2["hash"] == nil {
 			hash = ""
 		} else {
-			hash = fmt.Sprintf("%v", m["hash"])
+			hash = fmt.Sprintf("%v", m2["hash"])
 		}
 		return Import{Hash: hash, Path: fmt.Sprintf("%v", m2["Path"])}, nil
 	}

--- a/types/storage.go
+++ b/types/storage.go
@@ -76,4 +76,8 @@ type Storage interface {
 	// TarExtractLocation returns the location that a tar-based rootfs
 	// should be extracted to
 	TarExtractLocation(name string) string
+
+	// Add overlay_dirs into overlay metadata so that later we can mount them
+	// in the lxc container, works only for storage-type 'overlay'
+	SetOverlayDirs(name string, overlayDirs OverlayDirs, layerTypes []LayerType) error
 }


### PR DESCRIPTION
```
overlay_dirs:
    - source: example_dir
      dest: /path/to/target
```

This will copy source's contents into dest
in the target image, preserving permission,
links, times but not ownership.
source's contents will be packed into a
layer and added to the final image.