### PR TITLE
Inform user that cached layers are rebuilt if bind mounts are used

### DIFF
--- a/build.go
+++ b/build.go
@@ -398,6 +398,8 @@ func (b *Builder) Build(s types.Storage, file string) error {
 
 				log.Infof("missing some cached layer output types, building anyway")
 			}
+		} else if len(binds) > 0 {
+			log.Infof("rebuilding cached layer due to use of binds in stacker file")
 		}
 
 		err = SetupRootfs(baseOpts)

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -149,6 +149,7 @@ EOF
     # The layer should be built
     stacker build --substitute bind_path=${bind_path} --substitute CENTOS_OCI=$CENTOS_OCI
     out=$(stacker build --substitute bind_path=${bind_path} --substitute CENTOS_OCI=$CENTOS_OCI)
+    echo "${out}" | grep "rebuilding cached layer due to use of binds in stacker file"
     [[ "${out}" =~ ^(.*filesystem bind-test built successfully)$ ]]
 
     # TODO: FIXME: need to change the import. If stacker re-builds exactly the


### PR DESCRIPTION
Stacker will rebuild a cached layer if it uses bind mounts.  Emit an
info message so users understand stacker's behavior.

- Add a check in the cache test for the logged message