### PR TITLE
build: only emit rebuild message if cached and has binds

### DIFF
--- a/build.go
+++ b/build.go
@@ -398,7 +398,7 @@ func (b *Builder) Build(s types.Storage, file string) error {
 
 				log.Infof("missing some cached layer output types, building anyway")
 			}
-		} else if len(binds) > 0 {
+		} else if cacheHit && (len(binds) > 0) {
 			log.Infof("rebuilding cached layer due to use of binds in stacker file")
 		}
 

--- a/test/caching.bats
+++ b/test/caching.bats
@@ -149,7 +149,7 @@ EOF
     # The layer should be built
     stacker build --substitute bind_path=${bind_path} --substitute CENTOS_OCI=$CENTOS_OCI
     out=$(stacker build --substitute bind_path=${bind_path} --substitute CENTOS_OCI=$CENTOS_OCI)
-    echo "${out}" | grep "rebuilding cached layer due to use of binds in stacker file"
+    [[ "${out}" =~ ^(.*rebuilding cached layer due to use of binds in stacker file.*)$ ]]
     [[ "${out}" =~ ^(.*filesystem bind-test built successfully)$ ]]
 
     # TODO: FIXME: need to change the import. If stacker re-builds exactly the


### PR DESCRIPTION
We only want to emit the rebuildig message if the layer has been
built once and we have a cache hit.  Also switch back to bash pattern
matching in the test-case.  The previous attempt didn't account for the
fact that the output is a single line so matching a substring requires
accepting anything before and after the match.