### PR TITLE
import: drop chmod removal

### DIFF
--- a/import.go
+++ b/import.go
@@ -67,23 +67,6 @@ func filesDiffer(p1 string, info1 os.FileInfo, p2 string, info2 os.FileInfo) (bo
 	return !eq, nil
 }
 
-func chmodParentAndRemove(destpath string) (func(), error) {
-	// in the unpriv case, the dir might be -w (centos distributes its
-	// /root this way), and non-real root can't delete stuff that's -w,
-	// even if it is the owner. so let's chmod +w .. and try again.
-	dir := path.Dir(destpath)
-	orig, err := os.Stat(dir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't chmod +w ..")
-	}
-
-	err = os.Chmod(dir, 0700)
-	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't chmod +w ..")
-	}
-	return func() { os.Chmod(dir, orig.Mode()) }, os.RemoveAll(destpath)
-}
-
 func verifyImportFileHash(imp string, hash string) error {
 	if len(hash) == 0 {
 		return nil
@@ -164,17 +147,7 @@ func importFile(imp string, cacheDir string, hash string) (string, error) {
 			p := path.Join(cacheDir, path.Base(imp), d.Path())
 			err := os.RemoveAll(p)
 			if err != nil {
-				if os.IsPermission(err) {
-					var cleanup func()
-					cleanup, err = chmodParentAndRemove(p)
-					if cleanup != nil {
-						defer cleanup()
-					}
-				}
-
-				if err != nil {
-					return "", errors.Wrapf(err, "couldn't remove missing import %s", path.Join(cacheDir, path.Base(imp), d.Path()))
-				}
+				return "", errors.Wrapf(err, "couldn't remove missing import %s", path.Join(cacheDir, path.Base(imp), d.Path()))
 			}
 		case mtree.Modified:
 			fallthrough
@@ -184,17 +157,7 @@ func importFile(imp string, cacheDir string, hash string) (string, error) {
 
 			err = os.RemoveAll(destpath)
 			if err != nil && !os.IsNotExist(err) {
-				if os.IsPermission(err) {
-					var cleanup func()
-					cleanup, err = chmodParentAndRemove(destpath)
-					if cleanup != nil {
-						defer cleanup()
-					}
-				}
-
-				if err != nil {
-					return "", errors.Wrapf(err, "couldn't remove to replace import %s", destpath)
-				}
+				return "", errors.Wrapf(err, "couldn't remove to replace import %s", destpath)
 			}
 
 			sdirinfo, err := os.Lstat(path.Dir(srcpath))


### PR DESCRIPTION
This is a spiritual revert of the code in 9f46e4efbd23 ("import: handle
readonly parent directories") (but not the test); since we're now running
things inside a userns, the kernel's "is this thing root" checks pass and
we don't need to do this dance any more. Let's drop it.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>