### PR TITLE
lxc: allow "incomplete" apparmor profiles

### DIFF
--- a/container.go
+++ b/container.go
@@ -96,13 +96,14 @@ func NewContainer(sc types.StackerConfig, storage types.Storage, name string) (*
 	}
 
 	configs := map[string]string{
-		"lxc.mount.auto":  "proc:mixed",
-		"lxc.autodev":     "1",
-		"lxc.pty.max":     "1024",
-		"lxc.mount.entry": "none dev/shm tmpfs defaults,create=dir 0 0",
-		"lxc.uts.name":    name,
-		"lxc.net.0.type":  "none",
-		"lxc.environment": fmt.Sprintf("PATH=%s", ReasonableDefaultPath),
+		"lxc.mount.auto":                "proc:mixed",
+		"lxc.autodev":                   "1",
+		"lxc.pty.max":                   "1024",
+		"lxc.mount.entry":               "none dev/shm tmpfs defaults,create=dir 0 0",
+		"lxc.uts.name":                  name,
+		"lxc.net.0.type":                "none",
+		"lxc.environment":               fmt.Sprintf("PATH=%s", ReasonableDefaultPath),
+		"lxc.apparmor.allow_incomplete": "1",
 	}
 
 	if err := c.setConfigs(configs); err != nil {


### PR DESCRIPTION
Newer liblxcs reject starting on upstream kernels which don't have all the
same apparmor features that the Ubuntu kernels do. Let's set the flag so we
can actually run on upstream kernels. This avoids:

 2021-06-04 10:51:18.478 |  lxc build-env 20210604165117.604 ERROR    apparmor - lsm/apparmor.c:apparmor_prepare:1111 - If you really want to start this container, set
 2021-06-04 10:51:18.478 |  lxc build-env 20210604165117.604 ERROR    apparmor - lsm/apparmor.c:apparmor_prepare:1112 - lxc.apparmor.allow_incomplete = 1
 2021-06-04 10:51:18.478 |  lxc build-env 20210604165117.604 ERROR    apparmor - lsm/apparmor.c:apparmor_prepare:1113 - in your container configuration file
 2021-06-04 10:51:18.479 |  lxc build-env 20210604165117.605 ERROR    start - start.c:lxc_init:845 - Failed to initialize LSM

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>