### PR TITLE
tests: do a manual `umoci insert` to increase layer count

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -31,6 +31,7 @@ function image_copy {
 export CENTOS_OCI="$ROOT_DIR/test/centos:latest"
 [ -f "$ROOT_DIR/test/ubuntu/index.json" ] || image_copy docker://ubuntu:latest "oci:$ROOT_DIR/test/ubuntu:latest"
 export UBUNTU_OCI="$ROOT_DIR/test/ubuntu:latest"
+chmod -R 777 "$ROOT_DIR/test/centos" "$ROOT_DIR/test/ubuntu"
 
 function sha() {
     echo $(sha256sum $1 | cut -f1 -d" ")

--- a/test/intermediate-base-snapshots.bats
+++ b/test/intermediate-base-snapshots.bats
@@ -57,15 +57,17 @@ EOF
 function test_intermediate_layers {
     layer_type=$1
 
-    # as of this writing, the way the ubuntu image is generated it always has
-    # ~4 layers, although they are small. below we fail the test if there are
-    # not more than one layers, so that we can be sure the test always keeps
-    # testing things.
+    image_copy oci:$UBUNTU_OCI oci:./ubuntu:latest
+
+    touch foo
+    umoci insert --image ./ubuntu:latest foo /etc/foo
+    chmod -R 777 "./ubuntu"
+
     cat > stacker.yaml <<EOF
 test:
     from:
         type: oci
-        url: $UBUNTU_OCI
+        url: ./ubuntu:latest
 
 EOF
     stacker build --leave-unladen --layer-type=$layer_type


### PR DESCRIPTION
As the comment says, if ubuntu changes the way they generate their images
and only distribute one layer, we'll have to do something different.

Well, they did change it and the :latest images are now one layer. Let's
make them two layers manually via `umoci insert` of a bogus file.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>