### PR TITLE
tar base layers: fix computation of dependency order

### DIFF
--- a/build.go
+++ b/build.go
@@ -287,6 +287,8 @@ func (b *Builder) Build(s types.Storage, file string) error {
 		return err
 	}
 
+	log.Debugf("Dependency Order %v", order)
+
 	var oci casext.Engine
 	if _, statErr := os.Stat(opts.Config.OCIDir); statErr != nil {
 		oci, err = umoci.CreateLayout(opts.Config.OCIDir)

--- a/test/dependency-order.bats
+++ b/test/dependency-order.bats
@@ -34,3 +34,59 @@ EOF
     bad_stacker build
     echo "${output}" | grep "couldn't find dependencies for test: stacker://foo/bar, stacker://baz/foo"
 }
+
+@test "stacker:// style nesting w/ type built works" {
+    cat > stacker.yaml <<EOF
+minbase1:
+  from:
+    type: oci
+    url: $UBUNTU_OCI
+  run: |
+    echo pkgtool install cpio pigz
+
+installer-initrd:
+    build_only: true
+    from:
+        type: built
+        tag: minbase1
+    run: |
+        #!/bin/bash -ex
+        mkdir /output
+        touch /output/installer-initrd-base.cpio
+
+installer-initrd-modules:
+    from:
+        type: built
+        tag: installer-build-env
+    run: |
+        #!/bin/bash -ex
+        mkdir -p /output
+        touch /output/installer-initrd-modules.cpio
+
+installer-build-env:
+    from:
+        type: built
+        tag: minbase1
+    build_only: true
+
+installer-iso-build:
+    from:
+        type: built
+        tag: minbase1
+    build_only: true
+    import:
+        - stacker://installer-initrd/output/installer-initrd-base.cpio
+        - stacker://installer-initrd-modules/output/installer-initrd-modules.cpio
+    run: |
+        #!/bin/bash -ex
+        # populate the iso
+        mkdir /output
+        tar -cf /output/installer-iso.tar -C /stacker .
+
+atomix-installer-iso:
+    from:
+        type: tar
+        url: stacker://installer-iso-build/output/installer-iso.tar
+EOF
+    stacker build
+}

--- a/types/stackerfile.go
+++ b/types/stackerfile.go
@@ -297,9 +297,8 @@ func (s *Stackerfile) addPrerequisites(processed map[string]bool, sfm StackerFil
 	return nil
 }
 
-// DependencyOrder provides the list of layer names from a stackerfile
-// the current order to be built, note this method does not reorder the layers,
-// but it does validate they are specified in an order which makes sense
+// DependencyOrder provides the list of layer names from a stackerfile in the
+// order in which they should be built so all dependencies are satisfied.
 func (s *Stackerfile) DependencyOrder(sfm StackerFiles) ([]string, error) {
 	ret := []string{}
 	processed := map[string]bool{}
@@ -332,6 +331,20 @@ func (s *Stackerfile) DependencyOrder(sfm StackerFiles) ([]string, error) {
 			_, ok := processed[url.Host]
 			if !ok {
 				unprocessed = append(unprocessed, imp.Path)
+			}
+		}
+
+		if layer.From.Type == TarLayer {
+			url, err := NewDockerishUrl(layer.From.Url)
+			if err != nil {
+				return nil, err
+			}
+
+			if url.Scheme == "stacker" {
+				_, ok := processed[url.Host]
+				if !ok {
+					unprocessed = append(unprocessed, layer.From.Url)
+				}
 			}
 		}
 


### PR DESCRIPTION
The problem here is that we explicitly allow and document stacker:// style
imports for the url: portion of tar: base layers, so people can compose
tarballs in one layer and emit them in other layers.

However, the dependency order calculation did not take into account this
dependency. Let's add it to the computation.

Additionally, we fix a comment on DependencyOrder(), since it *does* in
fact re-order things now (and the comment had some poor grammar...)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>