### PR TITLE
build: variablize base image URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ STACKER_OPTS=--oci-dir=.build/oci --roots-dir=.build/roots --stacker-dir=.build/
 
 build_stacker = go build -tags "$(BUILD_TAGS)" -ldflags "-X main.version=$(VERSION_FULL) $1" -o $2 ./cmd
 
+STACKER_BUILD_BASE_IMAGE?=docker://alpine:edge
+
 stacker: stacker-dynamic
-	./stacker-dynamic --debug $(STACKER_OPTS) build -f build.yaml --shell-fail
+	./stacker-dynamic --debug $(STACKER_OPTS) build \
+		-f build.yaml --shell-fail --substitute STACKER_BUILD_BASE_IMAGE=$(STACKER_BUILD_BASE_IMAGE)
 
 stacker-static: $(GO_SRC) go.mod go.sum lxc-wrapper/lxc-wrapper
 	$(call build_stacker,-extldflags '-static',stacker)

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ build-env:
   build_only: true
   from:
     type: docker
-    url: docker://alpine:edge
+    url: ${{STACKER_BUILD_BASE_IMAGE}}
   run: |
     # libapparmor is only in testing
     head -n1 /etc/apk/repositories | sed 's/main/testing/g' >> /etc/apk/repositories


### PR DESCRIPTION
This will be useful for network-internal builds of stacker who can't
reference docker://alpine:edge directly.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>