### PR TITLE
make: add -f to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ vendorup:
 .PHONY: clean
 clean:
 	./stacker-dynamic $(STACKER_OPTS) clean
-	-rm -r stacker stacker-dynamic .build
+	-rm -rf stacker stacker-dynamic .build
 	-rm -r ./test/centos ./test/ubuntu
 	-make -C lxc-wrapper clean


### PR DESCRIPTION
Some things in the go cache are imported as -w, and so rm does interactive
prompts for these, which is annoying.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>