### PR TITLE
import: fix poor behavior

### DIFF
--- a/test/import.bats
+++ b/test/import.bats
@@ -178,3 +178,28 @@ centos:
 EOF
     bad_stacker build
 }
+
+@test "import a full directory tree with siblings" {
+    cat > stacker.yaml <<EOF
+centos:
+    from:
+        type: oci
+        url: $CENTOS_OCI
+    import:
+        - dir
+    run: |
+        find /stacker
+        [ -f /stacker/dir/one/two/three/four/five/a ]
+        [ -f /stacker/dir/file ]
+EOF
+
+    mkdir -p dir/one/two/three/four/five
+    touch dir/one/a
+    touch dir/one/two/a
+    touch dir/one/two/three/a
+    touch dir/one/two/three/four/a
+    touch dir/one/two/three/four/five/a
+    touch dir/file
+
+    stacker build
+}


### PR DESCRIPTION
There are two bugs here we fix.

1. lib.DirCopy() is recursive, but we the list of diffs is also recursive.
   So for a diff list like:

        /a
        /a/b
        /a/b/c

   we would end up copying c *three* times, once for /a, once for /a/b, and
   once for /a/b/c. While we switched away from cp -a to lib.DirCopy()
   recently, the bug existed previously with the cp -a version too. We've
   done lots of i/o we didn't need to do. c'est la vie :)

2. A correctness bug: go-mtree generates the diff list by putting paths in
   a golang map. golang maps are randomized, and thus the diff list can be
   generated in any order. So, for example, the diff list above could also
   be:

        /a/b/c
        /a/b
        /a

   Previously, on any new file, we would always os.RemoveAll() the target
   (in case the file switched from being a file to a directory, for
   example). However, this is incorrect for the above list, since on import
   of /a/b, we would remove /a/b which contained the already imported
   /a/b/c, and the resulting /stacker imports dir would not contain
   /stacker/a/b/c.

   Instead, let's *only* remove the target in the specific case we're
   concerned about: where the thing to be imported is a directory but
   whatever was there previously is not.

   We also add a test for this case, though since it's probabilistic it
   doesn't fail every time (but the deep nesting triggers it enough IME).

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>