### PR TITLE
cmd: add lxc version to --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@ GO_SRC=$(shell find . -path ./.build -prune -false -o -name \*.go)
 VERSION=$(shell git describe --tags || git rev-parse HEAD)
 VERSION_FULL=$(if $(shell git status --porcelain --untracked-files=no),$(VERSION)-dirty,$(VERSION))
 
+LXC_VERSION?=$(shell pkg-config --modversion lxc)
+
 BUILD_TAGS = exclude_graphdriver_devicemapper containers_image_openpgp osusergo netgo static_build
 
 STACKER_OPTS=--oci-dir=.build/oci --roots-dir=.build/roots --stacker-dir=.build/stacker --storage-type=overlay
 
-build_stacker = go build -tags "$(BUILD_TAGS)" -ldflags "-X main.version=$(VERSION_FULL) $1" -o $2 ./cmd
+build_stacker = go build -tags "$(BUILD_TAGS)" -ldflags "-X main.version=$(VERSION_FULL) -X main.lxc_version=$(LXC_VERSION) $1" -o $2 ./cmd
 
 STACKER_BUILD_BASE_IMAGE?=docker://alpine:edge
 

--- a/build.yaml
+++ b/build.yaml
@@ -29,6 +29,7 @@ build:
     # golang wants somewhere to put its garbage
     export HOME=/root
     export GOPATH=/stacker-tree/.build/gopath
+    export LXC_VERSION=$(git -C /lxc rev-parse HEAD)
 
     make -C /stacker-tree/lxc-wrapper clean
     make -C /stacker-tree stacker-static

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	config  types.StackerConfig
-	version = ""
+	config      types.StackerConfig
+	version     = ""
+	lxc_version = ""
 )
 
 func shouldShowProgress(ctx *cli.Context) bool {
@@ -64,7 +65,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "stacker"
 	app.Usage = "stacker builds OCI images"
-	app.Version = version
+	app.Version = fmt.Sprintf("stacker %s liblxc %s", version, lxc_version)
 
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {


### PR DESCRIPTION
Now that we're statically linking liblxc, it will likely be useful to know
exactly what version we're using:

~/packages/stacker master ./stacker --version
stacker version stacker v0.9.3-1-g2a431db-dirty liblxc e75ce64052f6c24790f5b2a98c617f29734a5165
~/packages/stacker master ./stacker-dynamic --version
stacker version stacker v0.9.3-1-g2a431db-dirty liblxc 4.0.9

Unfortunately the dynamically linked stacker doesn't exactly represent the
right version because liblxc's pkgconfig doesn't report it correctly (this is
some development version off of 4.0.9), but for the one that matters, the
statically linked one, we use rev-parse and thus should always get a hash.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>