### PR TITLE
internal: fixup apparmor profile detection

### DIFF
--- a/cmd/internal_go.go
+++ b/cmd/internal_go.go
@@ -107,6 +107,9 @@ func doCheckAAProfile(ctx *cli.Context) error {
 
 	err := ioutil.WriteFile(aaControlFile, []byte(command), 0000)
 	if err != nil {
+		if os.IsNotExist(err) {
+			os.Exit(52)
+		}
 		return errors.WithStack(err)
 	}
 


### PR DESCRIPTION
The kernel's procfs code disallows writing to /proc/pid/attr/current from a
different task:

static ssize_t proc_pid_attr_write(struct file * file, const char __user * buf,
                                   size_t count, loff_t *ppos)
{
        struct inode * inode = file_inode(file);
        struct task_struct *task;
        void *page;
        int rv;

	...
        /* A task may only write its own attributes. */
        if (current != task) {
                rcu_read_unlock();
                return -EACCES;
        }
	...

golang spawns lots of threads to do work in. /proc/self always refers to the
leader of the thread group, which may not be the task actually doing the
ioutil.WriteFile() (and indeed, most of the time is not), so we'd mostly (but
not always) get EACCES here.

Further, there is another race, since this check is done on write() and not
open(), if we open() things in one thread, and then write() in another, we'll
get EACCES.

Let's solve both of these by locking the OS thread for the duration of this
check, since it is not performance sensitive.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>