### PR TITLE
ci: run with go 1.17 too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         name: "golang ${{ matrix.go-version }} storage-type ${{ matrix.storage-type }} privilege ${{ matrix.privilege-level }}"
         strategy:
             matrix:
-                go-version: [1.16.x]
+                go-version: [1.16.x, 1.17.x]
                 storage-type: [btrfs, overlay]
                 privilege-level: [priv, unpriv]
         steps:


### PR DESCRIPTION
mostly it'll be interesting to see if the new register allocator will be
substantially faster for all of our pure go tar/gzip usage, which is mostly
what dominates stacker's cpu time.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>