### PR TITLE
overlay: test that the overlayMetadata structure is unchanged

### DIFF
--- a/overlay/metadata_test.go
+++ b/overlay/metadata_test.go
@@ -1,0 +1,20 @@
+package overlay
+
+import (
+	"testing"
+
+	"github.com/mitchellh/hashstructure"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverlayMetadataChanged(t *testing.T) {
+	assert := assert.New(t)
+
+	// see TestCacheEntryChanged for a full explanation, but if you need to
+	// bump this, you should bump the cache version as well since things
+	// may not be transferrable across versions.
+	h, err := hashstructure.Hash(overlayMetadata{}, nil)
+	assert.NoError(err)
+
+	assert.Equal(uint64(0x64bca1f8d0e31be2), h)
+}


### PR DESCRIPTION
If the overlay metadata structure changes, it probably implies a bug fix or
some other change in behavior, which previous overlay metadata will not
satisfy (even though they'll unparse correctly, the fields will just have
their "zero" value).

See the comment in TestCacheEntryChanged() for a full explanation, but
basically we should re-build everything if this structure has changed,
which means we should have a test for when it changes so that if people
change it, they know to bump the cache version.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>