### PR TITLE
import: add a hash check for http(s) imports 

### DIFF
--- a/import.go
+++ b/import.go
@@ -1,11 +1,12 @@
 package stacker
 
 import (
-	"github.com/opencontainers/go-digest"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/opencontainers/go-digest"
 
 	"github.com/anuvu/stacker/lib"
 	"github.com/anuvu/stacker/log"


### PR DESCRIPTION
This builds on top of 60cb730
Before this commit it only checked  HTTP header "X-Checksum-Sha256" with the hash provided in stacker.yaml

Now it also verifies the sha256 of the newly downloaded file on top of existing checks

Also resolves ~part1 of #206 