### PR TITLE
import: add flag to verify hash in remote imports

### DIFF
--- a/build.go
+++ b/build.go
@@ -28,6 +28,7 @@ type BuildArgs struct {
 	OnRunFailure string
 	LayerTypes   []types.LayerType
 	OrderOnly    bool
+	HashRequired bool
 	SetupOnly    bool
 	Progress     bool
 }
@@ -279,7 +280,7 @@ func (b *Builder) Build(s types.Storage, file string) error {
 		os.RemoveAll(opts.Config.StackerDir)
 	}
 
-	sf, err := types.NewStackerfile(file, append(opts.Substitute, b.opts.Config.Substitutions()...))
+	sf, err := types.NewStackerfile(file, opts.HashRequired, append(opts.Substitute, b.opts.Config.Substitutions()...))
 	if err != nil {
 		return err
 	}
@@ -543,7 +544,7 @@ func (b *Builder) BuildMultiple(paths []string) error {
 	defer locks.Unlock()
 
 	// Read all the stacker recipes
-	stackerFiles, err := types.NewStackerFiles(paths, append(opts.Substitute, b.opts.Config.Substitutions()...))
+	stackerFiles, err := types.NewStackerFiles(paths, opts.HashRequired, append(opts.Substitute, b.opts.Config.Substitutions()...))
 	if err != nil {
 		return err
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -56,7 +56,7 @@ foo:
 		t.Fatalf("couldn't write stacker yaml %v", err)
 	}
 
-	sf, err := types.NewStackerfile(stackerYaml, nil)
+	sf, err := types.NewStackerfile(stackerYaml, false, nil)
 	if err != nil {
 		t.Fatalf("couldn't read stacker file %v", err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -53,6 +53,10 @@ func initCommonBuildFlags() []cli.Flag {
 			Value: &cli.StringSlice{"tar"},
 		},
 		cli.BoolFlag{
+			Name:  "require-hash",
+			Usage: "require all remote imports to have a hash provided in stackerfiles",
+		},
+		cli.BoolFlag{
 			Name:  "order-only",
 			Usage: "show the build order without running the actual build",
 		},
@@ -86,6 +90,7 @@ func newBuildArgs(ctx *cli.Context) (stacker.BuildArgs, error) {
 		Substitute:   ctx.StringSlice("substitute"),
 		OnRunFailure: ctx.String("on-run-failure"),
 		OrderOnly:    ctx.Bool("order-only"),
+		HashRequired: ctx.Bool("require-hash"),
 		Progress:     shouldShowProgress(ctx),
 	}
 	var err error

--- a/cmd/chroot.go
+++ b/cmd/chroot.go
@@ -69,7 +69,7 @@ func doChroot(ctx *cli.Context) error {
 		defer c.Close()
 		return c.Execute(cmd, os.Stdin)
 	}
-	sf, err := types.NewStackerfile(file, ctx.StringSlice("substitute"))
+	sf, err := types.NewStackerfile(file, false, ctx.StringSlice("substitute"))
 	if err != nil {
 		return err
 	}

--- a/doc/stacker_yaml.md
+++ b/doc/stacker_yaml.md
@@ -98,6 +98,10 @@ import:
     hash: f805b012017bc769a....
 ```
 Before copying the file it will check if the requested hash matches the actual one.
+
+`stacker build` supports the flag `--require-flag` which checks that all http(s) remote
+imports have an hash in all stacker YAMLs.
+
 This new import mode can be combined with the old one, for example:
 ```
 import:

--- a/publisher.go
+++ b/publisher.go
@@ -192,7 +192,7 @@ func (p *Publisher) PublishMultiple(paths []string) error {
 func (p *Publisher) readStackerFiles(paths []string) (types.StackerFiles, error) {
 
 	// Read all the stacker recipes
-	sfm, err := types.NewStackerFiles(paths, append(p.opts.Substitute, p.opts.Config.Substitutions()...))
+	sfm, err := types.NewStackerFiles(paths, false, append(p.opts.Substitute, p.opts.Config.Substitutions()...))
 	if err != nil {
 
 		// Verify if the error is related to an invalid substitution

--- a/types/stackerfiles.go
+++ b/types/stackerfiles.go
@@ -11,7 +11,7 @@ type StackerFiles map[string]*Stackerfile
 
 // NewStackerFiles reads multiple Stackerfiles from a list of paths and applies substitutions
 // It adds the Stackerfiles mentioned in the prerequisite paths to the results
-func NewStackerFiles(paths []string, substituteVars []string) (StackerFiles, error) {
+func NewStackerFiles(paths []string, validateHash bool, substituteVars []string) (StackerFiles, error) {
 	sfm := make(map[string]*Stackerfile, len(paths))
 
 	// Iterate over list of paths to stackerfiles
@@ -19,7 +19,7 @@ func NewStackerFiles(paths []string, substituteVars []string) (StackerFiles, err
 		log.Debugf("initializing stacker recipe: %s", path)
 
 		// Read this stackerfile
-		sf, err := NewStackerfile(path, substituteVars)
+		sf, err := NewStackerfile(path, validateHash, substituteVars)
 		if err != nil {
 			return nil, err
 		}
@@ -40,7 +40,7 @@ func NewStackerFiles(paths []string, substituteVars []string) (StackerFiles, err
 		}
 
 		// Need to also add stackerfile dependencies of this stackerfile to the map of stackerfiles
-		depStackerFiles, err := NewStackerFiles(prerequisites, substituteVars)
+		depStackerFiles, err := NewStackerFiles(prerequisites, validateHash, substituteVars)
 		if err != nil {
 			return nil, err
 		}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -20,7 +20,7 @@ func parse(t *testing.T, content string) *Stackerfile {
 		t.Fatalf("couldn't write content: %s", err)
 	}
 
-	sf, err := NewStackerfile(tf.Name(), nil)
+	sf, err := NewStackerfile(tf.Name(), false, nil)
 	if err != nil {
 		t.Fatalf("failed to parse %s\n\n%s", content, err)
 	}


### PR DESCRIPTION
when stacker build is called with the flag `--require-hash`, it will fail the build if any remote import (http/https) doesn't have hash in its yaml entry.

```
--require-hash                  require all remote imports to have a hash provided in stackerfiles
```

*It still allows local or stacker imports without the hash*

Closes anuvu/stacker#206