### PR TITLE
container: move idmap stuff to its own package

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	stackeridmap "github.com/anuvu/stacker/container/idmap"
 	"github.com/anuvu/stacker/embed-exec"
 	"github.com/anuvu/stacker/log"
 	"github.com/anuvu/stacker/types"
@@ -85,7 +86,7 @@ func New(sc types.StackerConfig, storage types.Storage, name string) (*Container
 		return nil, err
 	}
 
-	idmapSet, err := ResolveCurrentIdmapSet()
+	idmapSet, err := stackeridmap.ResolveCurrentIdmapSet()
 	if err != nil {
 		return nil, err
 	}

--- a/container/idmap/idmap.go
+++ b/container/idmap/idmap.go
@@ -1,0 +1,62 @@
+package idmap
+
+import (
+	"os/user"
+	"strconv"
+
+	"github.com/lxc/lxd/shared/idmap"
+	"github.com/pkg/errors"
+)
+
+func ResolveCurrentIdmapSet() (*idmap.IdmapSet, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't resolve current user")
+	}
+	return resolveIdmapSet(currentUser)
+}
+
+func resolveIdmapSet(user *user.User) (*idmap.IdmapSet, error) {
+	idmapSet, err := idmap.DefaultIdmapSet("", user.Username)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed parsing /etc/sub{u,g}idmap")
+	}
+
+	if idmapSet != nil {
+		/* Let's make our current user the root user in the ns, so that when
+		 * stacker emits files, it does them as the right user.
+		 */
+		uid, err := strconv.Atoi(user.Uid)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't decode uid")
+		}
+
+		gid, err := strconv.Atoi(user.Gid)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't decode gid")
+		}
+		hostMap := []idmap.IdmapEntry{
+			idmap.IdmapEntry{
+				Isuid:    true,
+				Hostid:   int64(uid),
+				Nsid:     0,
+				Maprange: 1,
+			},
+			idmap.IdmapEntry{
+				Isgid:    true,
+				Hostid:   int64(gid),
+				Nsid:     0,
+				Maprange: 1,
+			},
+		}
+
+		for _, hm := range hostMap {
+			err := idmapSet.AddSafe(hm)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed adding idmap entry: %v", hm)
+			}
+		}
+	}
+
+	return idmapSet, nil
+}

--- a/container/userns.go
+++ b/container/userns.go
@@ -4,66 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
-	"strconv"
 
+	stackeridmap "github.com/anuvu/stacker/container/idmap"
 	"github.com/anuvu/stacker/log"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/pkg/errors"
 )
-
-func ResolveCurrentIdmapSet() (*idmap.IdmapSet, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't resolve current user")
-	}
-	return resolveIdmapSet(currentUser)
-}
-
-func resolveIdmapSet(user *user.User) (*idmap.IdmapSet, error) {
-	idmapSet, err := idmap.DefaultIdmapSet("", user.Username)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed parsing /etc/sub{u,g}idmap")
-	}
-
-	if idmapSet != nil {
-		/* Let's make our current user the root user in the ns, so that when
-		 * stacker emits files, it does them as the right user.
-		 */
-		uid, err := strconv.Atoi(user.Uid)
-		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't decode uid")
-		}
-
-		gid, err := strconv.Atoi(user.Gid)
-		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't decode gid")
-		}
-		hostMap := []idmap.IdmapEntry{
-			idmap.IdmapEntry{
-				Isuid:    true,
-				Hostid:   int64(uid),
-				Nsid:     0,
-				Maprange: 1,
-			},
-			idmap.IdmapEntry{
-				Isgid:    true,
-				Hostid:   int64(gid),
-				Nsid:     0,
-				Maprange: 1,
-			},
-		}
-
-		for _, hm := range hostMap {
-			err := idmapSet.AddSafe(hm)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed adding idmap entry: %v", hm)
-			}
-		}
-	}
-
-	return idmapSet, nil
-}
 
 func runInUserns(idmapSet *idmap.IdmapSet, userCmd []string) (*exec.Cmd, error) {
 	if idmapSet == nil {
@@ -110,7 +56,7 @@ func MaybeRunInUserns(userCmd []string) (*exec.Cmd, error) {
 		return cmd, nil
 	}
 
-	idmapSet, err := ResolveCurrentIdmapSet()
+	idmapSet, err := stackeridmap.ResolveCurrentIdmapSet()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Users of the "container" package now have to link against liblxc, and this
idmap code is useful on its own.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>