### PR TITLE
makefile: use better clean mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ vendorup:
 
 .PHONY: clean
 clean:
-	./stacker-dynamic $(STACKER_OPTS) clean
-	-rm -rf stacker stacker-dynamic .build
+	-unshare -Urm rm -rf stacker stacker-dynamic .build
 	-rm -r ./test/centos ./test/ubuntu
 	-make -C cmd/lxc-wrapper clean


### PR DESCRIPTION
`stacker clean` will work fine here for the stacker generated dirs, so long
as stacker was actually built successfully (which in some cases it may not
be). However, we put the go build cache in .build as well so we don't have
to re-download everything, and it creates files that are only +r for the
current user. rm -rf can't delete these for whatever reason, only root in a
user namespace can do that without first making it +w.

So, let's just be root in a user namespace. That fixes the problem with
broken stacker builds failing to clean things as well.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>