### PR TITLE
Fix make check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
                   sudo apt-get install -yy lxc-utils lxc-dev libacl1-dev jq libcap-dev libbtrfs-dev libseccomp-dev libpam-dev bats parallel
                   GO111MODULE=off go get github.com/opencontainers/umoci/cmd/umoci
                   sudo cp ~/go/bin/umoci /usr/bin
-                  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
+                  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
                   sudo apt-get install -yy autoconf automake make autogen autoconf libtool binutils git squashfs-tools
                   (cd /tmp && git clone https://github.com/AgentD/squashfs-tools-ng && cd squashfs-tools-ng && ./autogen.sh && ./configure --prefix=/usr && make -j2 && sudo make -j2 install && sudo ldconfig -v)
                   (cd /tmp && git clone https://github.com/anuvu/squashfs && cd squashfs && make && sudo cp squashtool/squashtool /usr/bin)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,7 +67,7 @@ func stackerResult(err error) {
 }
 
 func main() {
-	sigquits := make(chan os.Signal)
+	sigquits := make(chan os.Signal, 1)
 	go func() {
 		for range sigquits {
 			debug.PrintStack()
@@ -276,7 +276,7 @@ func main() {
 			cmd = append(cmd[:2], cmd[1:]...)
 			cmd[1] = "--internal-userns"
 
-			forward := make(chan os.Signal)
+			forward := make(chan os.Signal, 3)
 			signal.Notify(forward, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
 
 			c, err := container.MaybeRunInUserns(cmd)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -280,6 +280,9 @@ func main() {
 			signal.Notify(forward, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
 
 			c, err := container.MaybeRunInUserns(cmd)
+			if err != nil {
+				return err
+			}
 			if err = c.Start(); err != nil {
 				stackerResult(err)
 			}

--- a/container/container.go
+++ b/container/container.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 
 	stackeridmap "github.com/anuvu/stacker/container/idmap"
-	"github.com/anuvu/stacker/embed-exec"
+	embed_exec "github.com/anuvu/stacker/embed-exec"
 	"github.com/anuvu/stacker/log"
 	"github.com/anuvu/stacker/types"
 	"github.com/lxc/go-lxc"
@@ -294,7 +294,7 @@ func (c *Container) Execute(args string, stdin io.Reader) error {
 
 	}
 
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 32)
 	signal.Notify(signals)
 	done := make(chan bool)
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -31,13 +31,19 @@ https://golang.org/doc/install#install
 The other build dependencies can be satisfied with the following command and
 packages:
 
-    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev libpam0g-dev
+    sudo apt install lxc-dev libacl1-dev libgpgme-dev libcap-dev libseccomp-dev
+    libpam0g-dev libselinux-dev libssl-dev
 
 To run `make check` you will also need:
 
-    sudo add-apt-repository ppa:projectatomic/ppa
-    sudo apt update
-    sudo apt install bats jq
+    sudo apt install bats btrfs-progs jq libbtrfs-dev tree
+
+umoci - https://github.com/opencontainers/umoci
+squashtool - https://github.com/anuvu/squashfs
+
+Contrary to what the documentation in squashfs implies, squashtool and
+libsquash from squash-tools-ng need to be installed globally, as user specific
+path overrides aren't propagated into `make check`'s test envs.
 
 #### Fedora 31
 


### PR DESCRIPTION
Make check with a newer golangci-lint flagged some valid issues.

Channels for signal propagation need to be buffered.  Otherwise a dead lock can occur as unbuffered channels block the sender until the receiver checks for the message.  Real bad behavior if for instance the signal is on the same kernel thread as the go routine that's waiting for the signal.

An err variable was ignored.  The change simply prints the error and continues to maintain the existing semantics but adding debugging bread crumbs.  I welcome alternative suggestions for expected behavior.

Updated the docs with what was needed for the development lifecycle on a fairly fresh Ubuntu 20.04.  The ppa hasn't been updated for focal, but doesn't appear to need to be required.  Several packages commonly already installed weren't listed.  Specifics of how squashtool needs to be installed for `make check` added.

Fun fact:  if btrfs-progs isn't installed, a `make check` crashes the my Ubuntu's graphical env and dumps me out to a login prompt.  Might want to look at why at some point, but didn't see anything obvious in the regular logs.